### PR TITLE
Add reviewer metrics and filters

### DIFF
--- a/src/MetricsTable.jsx
+++ b/src/MetricsTable.jsx
@@ -3,6 +3,7 @@ import { Octokit } from '@octokit/rest';
 // Table is currently an experimental component so we import it from the
 // drafts entry point rather than the main package index.
 import { Table } from '@primer/react/drafts';
+import { Box, FormControl, Select } from '@primer/react';
 
 
 function formatDuration(start, end) {
@@ -18,37 +19,66 @@ function formatDuration(start, end) {
 export default function MetricsTable({ token }) {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [repoFilter, setRepoFilter] = useState('');
+  const [authorFilter, setAuthorFilter] = useState('');
 
   useEffect(() => {
     async function fetchData() {
       const octokit = new Octokit({ auth: token });
       try {
         const user = await octokit.rest.users.getAuthenticated();
-        const q = `is:pr author:${user.data.login}`;
-        const search = await octokit.rest.search.issuesAndPullRequests({ q });
+
+        const authored = await octokit.rest.search.issuesAndPullRequests({
+          q: `is:pr author:${user.data.login}`,
+          per_page: 100,
+        });
+
+        const reviewed = await octokit.rest.search.issuesAndPullRequests({
+          q: `is:pr reviewed-by:${user.data.login}`,
+          per_page: 100,
+        });
+
+        const allItems = new Map();
+        [...authored.data.items, ...reviewed.data.items].forEach((item) => {
+          allItems.set(item.id, item);
+        });
+
         const data = await Promise.all(
-          search.data.items.map(async (item) => {
+          Array.from(allItems.values()).map(async (item) => {
             const [owner, repo] = item.repository_url.split('/').slice(-2);
             const prNumber = item.number;
-            const { data: pr } = await octokit.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: prNumber,
-            });
-            const { data: reviews } = await octokit.rest.pulls.listReviews({
-              owner,
-              repo,
-              pull_number: prNumber,
-            });
 
-            let firstReview = null;
+            const prData = await octokit.graphql(
+              `query($owner:String!,$repo:String!,$number:Int!){
+                 repository(owner:$owner,name:$repo){
+                   pullRequest(number:$number){
+                     id
+                     title
+                     author { login }
+                     createdAt
+                     publishedAt
+                     closedAt
+                     mergedAt
+                     isDraft
+                     reviews(first:100){
+                       nodes{ author{login} state submittedAt }
+                     }
+                   }
+                 }
+               }`,
+              { owner, repo, number: prNumber }
+            );
+
+            const pr = prData.repository.pullRequest;
+
             const reviewers = new Set();
+            let firstReview = null;
             let changesRequested = 0;
-            reviews.forEach((rv) => {
-              reviewers.add(rv.user.login);
+            pr.reviews.nodes.forEach((rv) => {
+              if (rv.author) reviewers.add(rv.author.login);
               if (rv.state === 'CHANGES_REQUESTED') changesRequested += 1;
-              if (!firstReview || new Date(rv.submitted_at) < new Date(firstReview)) {
-                firstReview = rv.submitted_at;
+              if (!firstReview || new Date(rv.submittedAt) < new Date(firstReview)) {
+                firstReview = rv.submittedAt;
               }
             });
 
@@ -56,9 +86,11 @@ export default function MetricsTable({ token }) {
               id: pr.id,
               repo: `${owner}/${repo}`,
               title: pr.title,
-              state: pr.state,
-              created_at: pr.created_at,
-              closed_at: pr.merged_at || pr.closed_at,
+              author: pr.author ? pr.author.login : 'unknown',
+              state: pr.mergedAt ? 'merged' : pr.closedAt ? 'closed' : 'open',
+              created_at: pr.createdAt,
+              published_at: pr.publishedAt,
+              closed_at: pr.mergedAt || pr.closedAt,
               first_review_at: firstReview,
               reviewers: reviewers.size,
               changes_requested: changesRequested,
@@ -75,42 +107,84 @@ export default function MetricsTable({ token }) {
     fetchData();
   }, [token]);
 
+  const repos = Array.from(new Set(items.map((i) => i.repo))).sort();
+  const authors = Array.from(new Set(items.map((i) => i.author))).sort();
+
+  const filteredItems = items.filter((item) => {
+    return (
+      (!repoFilter || item.repo === repoFilter) &&
+      (!authorFilter || item.author === authorFilter)
+    );
+  });
+
   if (loading) {
     return <p>Loading...</p>;
   }
 
   return (
-    <Table.Container>
-      <Table aria-label="pull request metrics">
-        <Table.Head>
-          <Table.Row>
-            <Table.Cell header>Repository</Table.Cell>
-            <Table.Cell header>Title</Table.Cell>
-            <Table.Cell header>Reviewers</Table.Cell>
-            <Table.Cell header>Changes Requested</Table.Cell>
-            <Table.Cell header>First Review</Table.Cell>
-            <Table.Cell header>Time to Close</Table.Cell>
-            <Table.Cell header>State</Table.Cell>
-          </Table.Row>
-        </Table.Head>
-        <Table.Body>
-          {items.map((pr) => (
-            <Table.Row key={pr.id}>
-              <Table.Cell>{pr.repo}</Table.Cell>
-              <Table.Cell>{pr.title}</Table.Cell>
-              <Table.Cell>{pr.reviewers}</Table.Cell>
-              <Table.Cell>{pr.changes_requested}</Table.Cell>
-              <Table.Cell>
-                {formatDuration(pr.created_at, pr.first_review_at)}
-              </Table.Cell>
-              <Table.Cell>
-                {formatDuration(pr.created_at, pr.closed_at)}
-              </Table.Cell>
-              <Table.Cell>{pr.state}</Table.Cell>
+    <>
+      <Box display="flex" marginBottom={3} sx={{ gap: 3 }}>
+        <FormControl>
+          <FormControl.Label>Repository</FormControl.Label>
+          <Select value={repoFilter} onChange={(e) => setRepoFilter(e.target.value)}>
+            <Select.Option value="">All</Select.Option>
+            {repos.map((r) => (
+              <Select.Option key={r} value={r}>
+                {r}
+              </Select.Option>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl>
+          <FormControl.Label>Author</FormControl.Label>
+          <Select value={authorFilter} onChange={(e) => setAuthorFilter(e.target.value)}>
+            <Select.Option value="">All</Select.Option>
+            {authors.map((a) => (
+              <Select.Option key={a} value={a}>
+                {a}
+              </Select.Option>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+      <Table.Container>
+        <Table aria-label="pull request metrics">
+          <Table.Head>
+            <Table.Row>
+              <Table.Cell header>Repository</Table.Cell>
+              <Table.Cell header>Title</Table.Cell>
+              <Table.Cell header>Author</Table.Cell>
+              <Table.Cell header>Reviewers</Table.Cell>
+              <Table.Cell header>Changes Requested</Table.Cell>
+              <Table.Cell header>Draft Time</Table.Cell>
+              <Table.Cell header>First Review</Table.Cell>
+              <Table.Cell header>Time to Close</Table.Cell>
+              <Table.Cell header>State</Table.Cell>
             </Table.Row>
-          ))}
-        </Table.Body>
-      </Table>
-    </Table.Container>
+          </Table.Head>
+          <Table.Body>
+            {filteredItems.map((pr) => (
+              <Table.Row key={pr.id}>
+                <Table.Cell>{pr.repo}</Table.Cell>
+                <Table.Cell>{pr.title}</Table.Cell>
+                <Table.Cell>{pr.author}</Table.Cell>
+                <Table.Cell>{pr.reviewers}</Table.Cell>
+                <Table.Cell>{pr.changes_requested}</Table.Cell>
+                <Table.Cell>
+                  {formatDuration(pr.created_at, pr.published_at)}
+                </Table.Cell>
+                <Table.Cell>
+                  {formatDuration(pr.created_at, pr.first_review_at)}
+                </Table.Cell>
+                <Table.Cell>
+                  {formatDuration(pr.created_at, pr.closed_at)}
+                </Table.Cell>
+                <Table.Cell>{pr.state}</Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      </Table.Container>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- compute metrics for PRs created or reviewed by the authenticated user
- add time spent in draft column and show author
- allow filtering by repository and author
- update UI with Primer Select components

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684fe4d533dc832c93937d683abe5078