### PR TITLE
Use Primer background for whole app

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react';
+import {Box} from '@primer/react';
 import Login from './Login';
 import MetricsTable from './MetricsTable';
 
 export default function App() {
   const [token, setToken] = useState(null);
 
-  if (!token) {
-    return <Login onToken={setToken} />;
-  }
-
-  return <MetricsTable token={token} />;
+  return (
+    <Box bg="canvas.default" minHeight="100vh" p={3}>
+      {!token ? <Login onToken={setToken} /> : <MetricsTable token={token} />}
+    </Box>
+  );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+body {
+  margin: 0;
+}
+
+#root {
+  min-height: 100vh;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import {ThemeProvider, BaseStyles} from '@primer/react';
+import './index.css';
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
## Summary
- add a small CSS file for page base styles
- wrap `App` contents in a `Box` to apply background color and padding
- import the new CSS in the main entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ff157860c832c867b981366e0121f