### PR TITLE
Use Primer components in login

### DIFF
--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import {Box, Button, TextInput, Heading, Text} from '@primer/react';
 
 export default function Login({ onToken }) {
   const [value, setValue] = useState('');
@@ -11,18 +12,22 @@ export default function Login({ onToken }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} style={{ marginTop: '2rem', textAlign: 'center' }}>
-      <h1>GitHub PR Analyzer</h1>
-      <p>Enter a personal access token to continue:</p>
-      <input
+    <Box
+      as="form"
+      onSubmit={handleSubmit}
+      sx={{ mt: 4, textAlign: 'center' }}
+    >
+      <Heading as="h1">GitHub PR Analyzer</Heading>
+      <Text display="block" mt={2}>Enter a personal access token to continue:</Text>
+      <TextInput
         type="password"
         value={value}
         onChange={(e) => setValue(e.target.value)}
         placeholder="GitHub token"
       />
-      <button type="submit" style={{ marginLeft: '0.5rem' }}>
+      <Button type="submit" sx={{ ml: 2 }}>
         Sign in
-      </button>
-    </form>
+      </Button>
+    </Box>
   );
 }

--- a/src/MetricsTable.jsx
+++ b/src/MetricsTable.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Octokit } from '@octokit/rest';
 // Use the experimental DataTable component from Primer React
 import { DataTable, createColumnHelper } from '@primer/react/drafts';
-import { Box, FormControl, Select } from '@primer/react';
+import { Box, FormControl, Select, Text } from '@primer/react';
 
 
 function formatDuration(start, end) {
@@ -142,7 +142,7 @@ export default function MetricsTable({ token }) {
   ];
 
   if (loading) {
-    return <p>Loading...</p>;
+    return <Text>Loading...</Text>;
   }
 
   return (


### PR DESCRIPTION
## Summary
- switch Login form to Primer components
- use Primer `Text` while loading data

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ff4184e14832cb82576345d5c9c49