### PR TITLE
Add header with user profile and logout

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^20.0.0",
+    "@primer/octicons-react": "^19.0.0",
     "@primer/react": "^35.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,13 +2,19 @@ import React, { useState } from 'react';
 import {Box} from '@primer/react';
 import Login from './Login';
 import MetricsTable from './MetricsTable';
+import Header from './Header';
 
 export default function App() {
   const [token, setToken] = useState(null);
 
   return (
-    <Box bg="canvas.default" minHeight="100vh" p={3}>
-      {!token ? <Login onToken={setToken} /> : <MetricsTable token={token} />}
+    <Box bg="canvas.default" minHeight="100vh">
+      {token && (
+        <Header token={token} onLogout={() => setToken(null)} />
+      )}
+      <Box p={3}>
+        {!token ? <Login onToken={setToken} /> : <MetricsTable token={token} />}
+      </Box>
     </Box>
   );
 }

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -1,0 +1,46 @@
+import React, {useEffect, useState} from 'react';
+import {Box, Avatar, Text, Button} from '@primer/react';
+import {Octokit} from '@octokit/rest';
+import {GraphIcon} from '@primer/octicons-react';
+
+export default function Header({token, onLogout}) {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    async function fetchUser() {
+      const octokit = new Octokit({auth: token});
+      try {
+        const {data} = await octokit.rest.users.getAuthenticated();
+        setUser(data);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    fetchUser();
+  }, [token]);
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      justifyContent="space-between"
+      p={3}
+      borderBottomWidth="1px"
+      borderBottomStyle="solid"
+      borderColor="border.default"
+      sx={{bg: 'canvas.subtle'}}
+    >
+      <Box display="flex" alignItems="center" sx={{gap: 2}}>
+        <GraphIcon size={24} />
+        <Text fontWeight="bold">GitHub PR Analyzer</Text>
+      </Box>
+      {user && (
+        <Box display="flex" alignItems="center" sx={{gap: 2}}>
+          <Avatar src={user.avatar_url} size={24} />
+          <Text>{user.login}</Text>
+          <Button onClick={onLogout}>Logout</Button>
+        </Box>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add modern Header component using Primer
- integrate header into App and expose logout option
- include Octicons React dependency for icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ffafb8304832ca40f72e6b88cb35a