### PR TITLE
Make PR titles clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project is a simple React application that authenticates with GitHub and shows metrics for pull requests you have created or reviewed. It surfaces how long a pull request stayed in draft, the time to the first review and the total time until it was merged or closed. It also displays how many reviewers participated and how many change requests were made.
 
-The UI is built with [Primer](https://primer.style) components so that it feels similar to the GitHub interface. After signing in with GitHub, a table displays the pull requests along with filters for repository and author.
+The UI is built with [Primer](https://primer.style) components so that it feels similar to the GitHub interface. After signing in with GitHub, a table displays the pull requests along with filters for repository and author. Click any title in the table to open that pull request on GitHub.
 
 This repository contains only a minimal example client. You must supply a GitHub personal access token when prompted in the browser. Run the app with:
 

--- a/src/MetricsTable.jsx
+++ b/src/MetricsTable.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Octokit } from '@octokit/rest';
 // Use the experimental DataTable component from Primer React
 import { DataTable, Table, createColumnHelper } from '@primer/react/drafts';
-import { Box, FormControl, Select, Text, Spinner } from '@primer/react';
+import { Box, FormControl, Select, Text, Spinner, Link } from '@primer/react';
 
 
 function formatDuration(start, end) {
@@ -135,9 +135,18 @@ export default function MetricsTable({ token }) {
       id: 'title',
       header: 'Title',
       renderCell: row => (
-        <a href={row.url} target="_blank" rel="noopener noreferrer">
+        <Link
+          href={row.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          sx={{
+            color: 'fg.default',
+            textDecoration: 'none',
+            '&:hover': {color: 'accent.fg', textDecoration: 'underline'}
+          }}
+        >
           {row.title}
-        </a>
+        </Link>
       )
     }),
     columnHelper.column({id: 'author', header: 'Author', field: 'author'}),

--- a/src/MetricsTable.jsx
+++ b/src/MetricsTable.jsx
@@ -88,6 +88,7 @@ export default function MetricsTable({ token }) {
               id: pr.id,
               repo: `${owner}/${repo}`,
               title: pr.title,
+              url: item.html_url,
               author: pr.author ? pr.author.login : 'unknown',
               state: pr.mergedAt ? 'merged' : pr.closedAt ? 'closed' : 'open',
               created_at: pr.createdAt,
@@ -130,7 +131,15 @@ export default function MetricsTable({ token }) {
 
   const columns = [
     columnHelper.column({id: 'repo', header: 'Repository', field: 'repo', rowHeader: true}),
-    columnHelper.column({id: 'title', header: 'Title', field: 'title'}),
+    columnHelper.column({
+      id: 'title',
+      header: 'Title',
+      renderCell: row => (
+        <a href={row.url} target="_blank" rel="noopener noreferrer">
+          {row.title}
+        </a>
+      )
+    }),
     columnHelper.column({id: 'author', header: 'Author', field: 'author'}),
     columnHelper.column({id: 'reviewers', header: 'Reviewers', field: 'reviewers'}),
     columnHelper.column({id: 'changes_requested', header: 'Changes Requested', field: 'changes_requested'}),


### PR DESCRIPTION
## Summary
- add URL to each pull request record
- render PR titles as links that open the pull request in a new tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850070a1dec832ca3768bdad500cc30