### PR TITLE
Add timeline routing and table selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^20.0.0",
+        "@primer/octicons-react": "^19.0.0",
         "@primer/react": "^35.0.0",
         "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react-dom": "^18.0.0",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.0.0",
@@ -1060,6 +1062,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2636,6 +2647,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/remark-parse": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@primer/octicons-react": "^19.0.0",
     "@primer/react": "^35.0.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,19 +1,28 @@
 import React, { useState } from 'react';
 import {Box} from '@primer/react';
+import {Routes, Route, Navigate} from 'react-router-dom';
 import Login from './Login';
 import MetricsTable from './MetricsTable';
 import Header from './Header';
+import TimelinePage from './Timeline.jsx';
 
 export default function App() {
   const [token, setToken] = useState(null);
 
   return (
     <Box bg="canvas.default" minHeight="100vh">
-      {token && (
-        <Header token={token} onLogout={() => setToken(null)} />
-      )}
+      {token && <Header token={token} onLogout={() => setToken(null)} />}
       <Box p={3}>
-        {!token ? <Login onToken={setToken} /> : <MetricsTable token={token} />}
+        <Routes>
+          <Route
+            path="/"
+            element={!token ? <Login onToken={setToken} /> : <MetricsTable token={token} />}
+          />
+          <Route
+            path="/timeline/:owner/:repo/:number"
+            element={token ? <TimelinePage token={token} /> : <Navigate to="/" replace />}
+          />
+        </Routes>
       </Box>
     </Box>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import {Routes, Route, Navigate} from 'react-router-dom';
 import Login from './Login';
 import MetricsTable from './MetricsTable';
 import Header from './Header';
-import TimelinePage from './Timeline.jsx';
+import PullRequestPage from './PullRequest.jsx';
 
 export default function App() {
   const [token, setToken] = useState(null);
@@ -19,8 +19,8 @@ export default function App() {
             element={!token ? <Login onToken={setToken} /> : <MetricsTable token={token} />}
           />
           <Route
-            path="/timeline/:owner/:repo/:number"
-            element={token ? <TimelinePage token={token} /> : <Navigate to="/" replace />}
+            path="/pr/:owner/:repo/:number"
+            element={token ? <PullRequestPage token={token} /> : <Navigate to="/" replace />}
           />
         </Routes>
       </Box>

--- a/src/MetricsTable.jsx
+++ b/src/MetricsTable.jsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { Octokit } from '@octokit/rest';
 // Use the experimental DataTable component from Primer React
 import { DataTable, Table, createColumnHelper } from '@primer/react/drafts';
-import { Box, FormControl, Select, Text, Spinner, Link } from '@primer/react';
+import { Box, FormControl, Select, Text, Spinner, Link, Button } from '@primer/react';
+import {useNavigate} from 'react-router-dom';
 
 
 function formatDuration(start, end) {
@@ -21,8 +22,16 @@ export default function MetricsTable({ token }) {
   const [repoFilter, setRepoFilter] = useState('');
   const [authorFilter, setAuthorFilter] = useState('');
   const [pageIndex, setPageIndex] = useState(0);
+  const [selectedIds, setSelectedIds] = useState([]);
   const PAGE_SIZE = 25;
   const columnHelper = createColumnHelper();
+  const navigate = useNavigate();
+
+  const toggleSelect = (id) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]
+    );
+  };
 
   useEffect(() => {
     async function fetchData() {
@@ -86,7 +95,10 @@ export default function MetricsTable({ token }) {
 
             return {
               id: pr.id,
+              owner,
+              repo_name: repo,
               repo: `${owner}/${repo}`,
+              number: prNumber,
               title: pr.title,
               url: item.html_url,
               author: pr.author ? pr.author.login : 'unknown',
@@ -97,6 +109,12 @@ export default function MetricsTable({ token }) {
               first_review_at: firstReview,
               reviewers: reviewers.size,
               changes_requested: changesRequested,
+              timeline: [
+                {label: 'Created', date: pr.createdAt},
+                {label: 'Published', date: pr.publishedAt},
+                {label: 'First review', date: firstReview},
+                {label: 'Closed', date: pr.mergedAt || pr.closedAt}
+              ].filter(e => e.date)
             };
           })
         );
@@ -129,7 +147,20 @@ export default function MetricsTable({ token }) {
     pageIndex * PAGE_SIZE + PAGE_SIZE
   );
 
+  const selectedItem = items.find((i) => selectedIds.includes(i.id));
+
   const columns = [
+    columnHelper.column({
+      id: 'select',
+      header: '',
+      renderCell: row => (
+        <input
+          type="checkbox"
+          checked={selectedIds.includes(row.id)}
+          onChange={() => toggleSelect(row.id)}
+        />
+      )
+    }),
     columnHelper.column({id: 'repo', header: 'Repository', field: 'repo', rowHeader: true}),
     columnHelper.column({
       id: 'title',
@@ -213,6 +244,13 @@ export default function MetricsTable({ token }) {
           </Select>
         </FormControl>
       </Box>
+      {selectedIds.length === 1 && (
+        <Box marginBottom={2}>
+          <Button onClick={() => navigate(`/timeline/${selectedItem.owner}/${selectedItem.repo_name}/${selectedItem.number}`, { state: selectedItem })}>
+            View timeline
+          </Button>
+        </Box>
+      )}
       <DataTable
         aria-labelledby="pr-table"
         columns={columns}

--- a/src/MetricsTable.jsx
+++ b/src/MetricsTable.jsx
@@ -246,8 +246,8 @@ export default function MetricsTable({ token }) {
       </Box>
       {selectedIds.length === 1 && (
         <Box marginBottom={2}>
-          <Button onClick={() => navigate(`/timeline/${selectedItem.owner}/${selectedItem.repo_name}/${selectedItem.number}`, { state: selectedItem })}>
-            View timeline
+          <Button onClick={() => navigate(`/pr/${selectedItem.owner}/${selectedItem.repo_name}/${selectedItem.number}`, { state: selectedItem })}>
+            View pull request
           </Button>
         </Box>
       )}

--- a/src/Timeline.jsx
+++ b/src/Timeline.jsx
@@ -1,0 +1,83 @@
+import React, {useEffect, useState} from 'react';
+import {Octokit} from '@octokit/rest';
+import {Timeline} from '@primer/react';
+import {Box, Spinner, Button, Text} from '@primer/react';
+import {useParams, useLocation, Link as RouterLink} from 'react-router-dom';
+
+export default function TimelinePage({token}) {
+  const {owner, repo, number} = useParams();
+  const location = useLocation();
+  const [events, setEvents] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchData() {
+      if (location.state && location.state.timeline) {
+        setEvents(location.state.timeline);
+        setLoading(false);
+        return;
+      }
+      const octokit = new Octokit({auth: token});
+      try {
+        const {repository} = await octokit.graphql(
+          `query($owner:String!,$repo:String!,$number:Int!){
+            repository(owner:$owner,name:$repo){
+              pullRequest(number:$number){
+                createdAt
+                publishedAt
+                closedAt
+                mergedAt
+                reviews(first:100){ nodes{ submittedAt } }
+              }
+            }
+          }`,
+          {owner, repo, number: parseInt(number, 10)}
+        );
+        const pr = repository.pullRequest;
+        const firstReview = pr.reviews.nodes.reduce((acc, rv) => {
+          return !acc || new Date(rv.submittedAt) < new Date(acc)
+            ? rv.submittedAt
+            : acc;
+        }, null);
+        const timeline = [
+          {label: 'Created', date: pr.createdAt},
+          {label: 'Published', date: pr.publishedAt},
+          {label: 'First review', date: firstReview},
+          {label: 'Closed', date: pr.mergedAt || pr.closedAt}
+        ].filter(e => e.date);
+        setEvents(timeline);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, [token, owner, repo, number, location.state]);
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" p={3}>
+        <Spinner size="large" />
+      </Box>
+    );
+  }
+
+  return (
+    <Box p={3}>
+      <Button as={RouterLink} to="/" sx={{mb: 3}}>
+        Back
+      </Button>
+      <Timeline>
+        {events.map((ev, i) => (
+          <Timeline.Item key={i}>
+            <Timeline.Badge />
+            <Timeline.Body>
+              <Text>{`${ev.label}: ${new Date(ev.date).toLocaleString()}`}</Text>
+            </Timeline.Body>
+          </Timeline.Item>
+        ))}
+      </Timeline>
+    </Box>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import {ThemeProvider, BaseStyles} from '@primer/react';
+import {BrowserRouter} from 'react-router-dom';
 import './index.css';
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <ThemeProvider colorMode="auto">
-      <BaseStyles>
-        <App />
-      </BaseStyles>
-    </ThemeProvider>
+    <BrowserRouter>
+      <ThemeProvider colorMode="auto">
+        <BaseStyles>
+          <App />
+        </BaseStyles>
+      </ThemeProvider>
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- enable routing with react-router-dom
- allow selecting pull requests
- show 'View timeline' button when a PR is selected
- navigate to a new timeline view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68500882e908832cb40524b788572dab