### PR TITLE
Improve PAT instructions on login

### DIFF
--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -5,7 +5,8 @@ import {
   TextInput,
   Heading,
   Text,
-  FormControl
+  FormControl,
+  Link
 } from '@primer/react';
 import {SignInIcon} from '@primer/octicons-react';
 
@@ -88,7 +89,9 @@ export default function Login({ onToken }) {
                     </Text>
                   </li>
                   <li>
-                    <Text as="span" fontSize={1}>Copy the token and paste it here.</Text>
+                    <Text as="span" fontSize={1}>
+                      Copy the token and paste it here.
+                    </Text>
                   </li>
                 </Box>
               </details>

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -55,6 +55,44 @@ export default function Login({ onToken }) {
             <FormControl.Caption>
               <Text fontSize={1}>Your token is used only in the browser</Text>
             </FormControl.Caption>
+            <Box mt={2}>
+              <details>
+                <summary>
+                  <Text fontSize={1} sx={{cursor: 'pointer'}}>
+                    Additional info for generating a personal access token
+                  </Text>
+                </summary>
+                <Box as="ol" pl={3} mt={2}>
+                  <li>
+                    <Text as="span" fontSize={1}>
+                      Visit{' '}
+                      <Link
+                        href="https://github.com/settings/tokens"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        GitHub settings
+                      </Link>
+                      .
+                    </Text>
+                  </li>
+                  <li>
+                    <Text as="span" fontSize={1}>
+                      Generate a new fine‑grained token with read‑only
+                      repository access.
+                    </Text>
+                  </li>
+                  <li>
+                    <Text as="span" fontSize={1}>
+                      Enable SSO for your organization when prompted.
+                    </Text>
+                  </li>
+                  <li>
+                    <Text as="span" fontSize={1}>Copy the token and paste it here.</Text>
+                  </li>
+                </Box>
+              </details>
+            </Box>
           </FormControl>
           <Button
             type="submit"


### PR DESCRIPTION
## Summary
- add collapsible notes describing how to create a GitHub personal access token

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68503f86a518832ca154e36ba6e278d2