### PR TITLE
Add localized date formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@octokit/rest": "^20.0.0",
         "@primer/octicons-react": "^19.0.0",
         "@primer/react": "^35.0.0",
+        "date-fns": "^4.1.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.30.1"
@@ -1569,6 +1570,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@octokit/rest": "^20.0.0",
     "@primer/octicons-react": "^19.0.0",
     "@primer/react": "^35.0.0",
+    "date-fns": "^4.1.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.1"

--- a/src/MetricsTable.jsx
+++ b/src/MetricsTable.jsx
@@ -14,16 +14,7 @@ import {
   Tooltip,
 } from "@primer/react";
 import { useNavigate } from "react-router-dom";
-
-function formatDuration(start, end) {
-  if (!start || !end) return "N/A";
-  const diffMs = new Date(end) - new Date(start);
-  if (diffMs < 0) return "N/A";
-  const diffHours = Math.floor(diffMs / 36e5);
-  const days = Math.floor(diffHours / 24);
-  const hours = diffHours % 24;
-  return days > 0 ? `${days}d ${hours}h` : `${hours}h`;
-}
+import formatDuration from "./utils/formatDuration";
 
 export default function MetricsTable({ token }) {
   const [items, setItems] = useState([]);

--- a/src/utils/formatDuration.js
+++ b/src/utils/formatDuration.js
@@ -1,0 +1,23 @@
+import {formatDuration as dfFormatDuration, intervalToDuration} from 'date-fns';
+import {enUS, fr, es, de, zhCN} from 'date-fns/locale';
+
+const LOCALES = {
+  en: enUS,
+  fr,
+  es,
+  de,
+  zh: zhCN,
+};
+
+export default function formatDuration(start, end) {
+  if (!start || !end) return 'N/A';
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  if (isNaN(startDate) || isNaN(endDate) || endDate < startDate) return 'N/A';
+
+  const duration = intervalToDuration({start: startDate, end: endDate});
+  const langCode = (navigator.language || 'en').split('-')[0];
+  const locale = LOCALES[langCode] || enUS;
+
+  return dfFormatDuration(duration, {format: ['days', 'hours'], zero: false, locale});
+}


### PR DESCRIPTION
## Summary
- add `date-fns` library
- implement `formatDuration` helper using `date-fns` with locale support
- replace inline duration logic in `MetricsTable` with helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68504c840f38832cb7aa8687c9551b30