### PR TITLE
Implement auth context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,27 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {Box} from '@primer/react';
 import {Routes, Route, Navigate} from 'react-router-dom';
 import Login from './Login';
 import MetricsTable from './MetricsTable';
 import Header from './Header';
 import PullRequestPage from './PullRequest';
+import {useAuth} from './AuthContext';
 
 export default function App() {
-  const [token, setToken] = useState<string | null>(null);
+  const {token} = useAuth();
 
   return (
     <Box bg="canvas.default" minHeight="100vh">
-      {token && <Header token={token} onLogout={() => setToken(null)} />}
+      {token && <Header />}
       <Box p={3}>
         <Routes>
           <Route
             path="/"
-            element={!token ? <Login onToken={setToken} /> : <MetricsTable token={token} />}
+            element={!token ? <Login /> : <MetricsTable />}
           />
           <Route
             path="/pr/:owner/:repo/:number"
-            element={token ? <PullRequestPage token={token} /> : <Navigate to="/" replace />}
+            element={token ? <PullRequestPage /> : <Navigate to="/" replace />}
           />
         </Routes>
       </Box>

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -1,0 +1,27 @@
+import React, {createContext, useState, useContext} from 'react';
+
+interface AuthContextValue {
+  token: string | null;
+  login: (token: string) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider: React.FC<{children: React.ReactNode}> = ({children}) => {
+  const [token, setToken] = useState<string | null>(null);
+  const login = (newToken: string) => setToken(newToken);
+  const logout = () => setToken(null);
+
+  return (
+    <AuthContext.Provider value={{token, login, logout}}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -2,18 +2,15 @@ import React, { useEffect, useState } from 'react';
 import { Box, Avatar, Text, Button } from '@primer/react';
 import { Octokit } from '@octokit/rest';
 import { GraphIcon } from '@primer/octicons-react';
-
-interface HeaderProps {
-  token: string;
-  onLogout: () => void;
-}
+import { useAuth } from './AuthContext';
 
 interface GitHubUser {
   login: string;
   avatar_url: string;
 }
 
-export default function Header({ token, onLogout }: HeaderProps) {
+export default function Header() {
+  const {token, logout} = useAuth();
   const [user, setUser] = useState<GitHubUser | null>(null);
 
   useEffect(() => {
@@ -48,7 +45,7 @@ export default function Header({ token, onLogout }: HeaderProps) {
         <Box display="flex" alignItems="center" sx={{gap: 2}}>
           <Avatar src={user.avatar_url} size={24} />
           <Text>{user.login}</Text>
-          <Button onClick={onLogout}>Logout</Button>
+          <Button onClick={logout}>Logout</Button>
         </Box>
       )}
     </Box>

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -10,17 +10,16 @@ import {
 } from '@primer/react';
 import {SignInIcon} from '@primer/octicons-react';
 
-interface LoginProps {
-  onToken: (token: string) => void;
-}
+import {useAuth} from './AuthContext';
 
-export default function Login({ onToken }: LoginProps) {
+export default function Login() {
+  const {login} = useAuth();
   const [value, setValue] = useState('');
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (value) {
-      onToken(value.trim());
+      login(value.trim());
     }
   };
 

--- a/src/MetricsTable.tsx
+++ b/src/MetricsTable.tsx
@@ -15,10 +15,7 @@ import {
 import { useNavigate } from "react-router-dom";
 import { usePullRequestMetrics } from "./hooks/usePullRequestMetrics";
 import { PRItem } from "./types";
-
-interface MetricsTableProps {
-  token: string;
-}
+import { useAuth } from "./AuthContext";
 
 
 
@@ -32,8 +29,9 @@ function formatDuration(start?: string | null, end?: string | null) {
   return days > 0 ? `${days}d ${hours}h` : `${hours}h`;
 }
 
-export default function MetricsTable({ token }: MetricsTableProps) {
-  const { items, loading } = usePullRequestMetrics(token);
+export default function MetricsTable() {
+  const {token} = useAuth();
+  const { items, loading } = usePullRequestMetrics(token!);
   const [repoFilter, setRepoFilter] = useState<string>("");
   const [authorFilter, setAuthorFilter] = useState<string>("");
   const [pageIndex, setPageIndex] = useState<number>(0);

--- a/src/PullRequest.tsx
+++ b/src/PullRequest.tsx
@@ -3,16 +3,14 @@ import { Octokit } from '@octokit/rest';
 import { Timeline, Heading, TabNav } from '@primer/react';
 import { Box, Spinner, Button, Text } from '@primer/react';
 import { useParams, useLocation, Link as RouterLink } from 'react-router-dom';
-
-interface PullRequestPageProps {
-  token: string;
-}
+import { useAuth } from './AuthContext';
 
 interface TimelineEntry {
   label: string;
   date: string;
 }
-export default function PullRequestPage({ token }: PullRequestPageProps) {
+export default function PullRequestPage() {
+  const {token} = useAuth();
   const {owner, repo, number} = useParams();
   const location = useLocation();
   const [events, setEvents] = useState<TimelineEntry[] | null>(null);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,13 +4,16 @@ import {ThemeProvider, BaseStyles} from '@primer/react';
 import {BrowserRouter} from 'react-router-dom';
 import './index.css';
 import App from './App';
+import {AuthProvider} from './AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
       <ThemeProvider colorMode="auto">
         <BaseStyles>
-          <App />
+          <AuthProvider>
+            <App />
+          </AuthProvider>
         </BaseStyles>
       </ThemeProvider>
     </BrowserRouter>


### PR DESCRIPTION
## Summary
- add `AuthProvider` and `useAuth` hook
- use context token in `App`, `Header`, `Login`, `MetricsTable` and `PullRequestPage`
- wrap app with provider in `main.tsx`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68505805f6f0832cb4c4e98ffb6f654a