### PR TITLE
Add breadcrumb navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The user interface relies on [Primer](https://primer.style) to match the look an
 - Display reviewer count and change requests.
 - Filter by repository and author.
 - Direct links to each pull request.
+- Breadcrumb navigation for quick orientation.
 
 ## Architecture
 
@@ -87,4 +88,4 @@ The compiled files will be available in the `build/` directory.
 
 This project is released under the [MIT License](LICENSE).
 
-Line coverage: 84.57%
+Line coverage: 85.37%

--- a/src/BreadcrumbNav.tsx
+++ b/src/BreadcrumbNav.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Box, Breadcrumbs } from '@primer/react';
+import { Link as RouterLink, useLocation, useParams } from 'react-router-dom';
+
+export default function BreadcrumbNav() {
+  const location = useLocation();
+  const { owner, repo, number } = useParams();
+
+  const items = [
+    <Breadcrumbs.Item key="home" as={RouterLink} to="/">
+      Pull Requests
+    </Breadcrumbs.Item>,
+  ];
+
+  if (location.pathname.startsWith('/pr/')) {
+    items.push(
+      <Breadcrumbs.Item key="pr">{`${owner}/${repo} #${number}`}</Breadcrumbs.Item>
+    );
+  }
+
+  return (
+    <Box
+      p={3}
+      borderBottomWidth="1px"
+      borderBottomStyle="solid"
+      borderColor="border.default"
+      sx={{ bg: 'canvas.subtle' }}
+    >
+      <Breadcrumbs>{items}</Breadcrumbs>
+    </Box>
+  );
+}

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -3,6 +3,7 @@ import { Box, Avatar, Text, Button } from '@primer/react';
 import { Octokit } from '@octokit/rest';
 import { GraphIcon } from '@primer/octicons-react';
 import { useAuth } from './AuthContext';
+import BreadcrumbNav from './BreadcrumbNav';
 
 interface GitHubUser {
   login: string;
@@ -27,27 +28,27 @@ export default function Header() {
   }, [token]);
 
   return (
-    <Box
-      display="flex"
-      alignItems="center"
-      justifyContent="space-between"
-      p={3}
-      borderBottomWidth="1px"
-      borderBottomStyle="solid"
-      borderColor="border.default"
-      sx={{ bg: 'canvas.subtle' }}
-    >
-      <Box display="flex" alignItems="center" sx={{ gap: 2 }}>
-        <GraphIcon size={24} />
-        <Text fontWeight="bold">GitHub PR Analyzer</Text>
-      </Box>
-      {user && (
+    <Box>
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="space-between"
+        p={3}
+        sx={{ bg: 'canvas.subtle' }}
+      >
         <Box display="flex" alignItems="center" sx={{ gap: 2 }}>
-          <Avatar src={user.avatar_url} size={24} />
-          <Text>{user.login}</Text>
-          <Button onClick={logout}>Logout</Button>
+          <GraphIcon size={24} />
+          <Text fontWeight="bold">GitHub PR Analyzer</Text>
         </Box>
-      )}
+        {user && (
+          <Box display="flex" alignItems="center" sx={{ gap: 2 }}>
+            <Avatar src={user.avatar_url} size={24} />
+            <Text>{user.login}</Text>
+            <Button onClick={logout}>Logout</Button>
+          </Box>
+        )}
+      </Box>
+      <BreadcrumbNav />
     </Box>
   );
 }

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -47,4 +47,5 @@ test('shows metrics table when authenticated', async () => {
   );
   expect(screen.getByLabelText('Repository')).toBeInTheDocument();
   expect(screen.getByText('GitHub PR Analyzer')).toBeInTheDocument();
+  expect(screen.getByText('Pull Requests')).toBeInTheDocument();
 });

--- a/src/__tests__/BreadcrumbNav.test.tsx
+++ b/src/__tests__/BreadcrumbNav.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import BreadcrumbNav from '../BreadcrumbNav';
+
+function renderWithRouter(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="*" element={<BreadcrumbNav />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+test('renders root breadcrumb', () => {
+  renderWithRouter('/');
+  expect(screen.getByText('Pull Requests')).toBeInTheDocument();
+});
+
+test('renders PR breadcrumb', () => {
+  render(
+    <MemoryRouter initialEntries={['/pr/octo/repo/1']}>
+      <Routes>
+        <Route path="/pr/:owner/:repo/:number" element={<BreadcrumbNav />} />
+      </Routes>
+    </MemoryRouter>
+  );
+  expect(screen.getByText('octo/repo #1')).toBeInTheDocument();
+});

--- a/src/__tests__/Header.test.tsx
+++ b/src/__tests__/Header.test.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import Header from '../Header';
 import { AuthProvider, useAuth } from '../AuthContext';
 import { Octokit } from '@octokit/rest';
@@ -20,7 +21,11 @@ test('fetches and displays user info', async () => {
     useEffect(() => {
       auth.login('token');
     }, [auth]);
-    return <Header />;
+    return (
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
   }
 
   render(
@@ -31,4 +36,5 @@ test('fetches and displays user info', async () => {
 
   await waitFor(() => expect(screen.getByText('octo')).toBeInTheDocument());
   expect(Octokit).toHaveBeenCalledWith({ auth: 'token' });
+  expect(screen.getByText('Pull Requests')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add BreadcrumbNav component to display breadcrumbs
- integrate breadcrumbs into App layout
- document breadcrumb feature in README
- cover breadcrumbs with new unit tests

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_685067b0d7ac832c824eeaf94744a1ec