### PR TITLE
Display reviewer names as links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub PR Analyzer
 
-GitHub PR Analyzer is a small React and TypeScript application for exploring metrics about your pull requests. It surfaces how long a pull request stayed in draft, the time to the first review and the total time until it was merged or closed. The app also reports how many reviewers participated and how many change requests were made.
+GitHub PR Analyzer is a small React and TypeScript application for exploring metrics about your pull requests. It surfaces how long a pull request stayed in draft, the time to the first review and the total time until it was merged or closed. The app also shows who reviewed the pull requests and how many change requests were made.
 
 The user interface relies on [Primer](https://primer.style) to match the look and feel of GitHub. After signing in with your GitHub token, a table displays the pull requests with filters for repository and author. Selecting a title in the table opens the pull request on GitHub.
 
@@ -19,7 +19,7 @@ The user interface relies on [Primer](https://primer.style) to match the look an
 - Authenticate with a personal access token.
 - View pull requests you authored or reviewed.
 - Metrics for draft time, first review and total lifespan.
-- Display reviewer count and change requests.
+ - Display reviewer names with links and change requests.
 - Filter by repository and author.
 - Direct links to each pull request.
 

--- a/src/MetricsTable.tsx
+++ b/src/MetricsTable.tsx
@@ -117,7 +117,22 @@ export default function MetricsTable() {
     columnHelper.column({
       id: 'reviewers',
       header: 'Reviewers',
-      field: 'reviewers',
+      renderCell: (row) => (
+        <>
+          {row.reviewers.map((name: string, idx: number) => (
+            <React.Fragment key={name}>
+              <Link
+                href={`https://github.com/${name}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {name}
+              </Link>
+              {idx < row.reviewers.length - 1 && ', '}
+            </React.Fragment>
+          ))}
+        </>
+      ),
     }),
     columnHelper.column({
       id: 'changes_requested',

--- a/src/__tests__/MetricsTable.test.tsx
+++ b/src/__tests__/MetricsTable.test.tsx
@@ -28,7 +28,7 @@ const sample: PRItem[] = [
     closed_at: '2020-01-03',
     first_review_at: '2020-01-02',
     first_commit_at: '2020-01-01',
-    reviewers: 1,
+    reviewers: ['reviewer1'],
     changes_requested: 0,
     additions: 1,
     deletions: 1,

--- a/src/__tests__/usePullRequestMetrics.test.ts
+++ b/src/__tests__/usePullRequestMetrics.test.ts
@@ -19,7 +19,7 @@ const sample: PRItem[] = [
     closed_at: '2020-01-03',
     first_review_at: '2020-01-02',
     first_commit_at: '2020-01-01',
-    reviewers: 1,
+    reviewers: ['reviewer1'],
     changes_requested: 0,
     additions: 1,
     deletions: 1,

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -65,11 +65,11 @@ export async function fetchPullRequestMetrics(
           : earliest;
       }, null);
 
-      const reviewers = new Set<string>();
+      const reviewerSet = new Set<string>();
       let firstReview: string | null = null;
       let changesRequested = 0;
       pr.reviews.nodes.forEach((rv: any) => {
-        if (rv.author) reviewers.add(rv.author.login);
+        if (rv.author) reviewerSet.add(rv.author.login);
         if (rv.state === 'CHANGES_REQUESTED') changesRequested += 1;
         if (!firstReview || new Date(rv.submittedAt) < new Date(firstReview)) {
           firstReview = rv.submittedAt;
@@ -97,7 +97,7 @@ export async function fetchPullRequestMetrics(
         closed_at: pr.mergedAt || pr.closedAt,
         first_review_at: firstReview,
         first_commit_at: firstCommitAt,
-        reviewers: reviewers.size,
+        reviewers: Array.from(reviewerSet),
         changes_requested: changesRequested,
         additions: pr.additions,
         deletions: pr.deletions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export interface PRItem {
   closed_at?: string;
   first_review_at?: string | null;
   first_commit_at?: string | null;
-  reviewers: number;
+  reviewers: string[];
   changes_requested: number;
   additions: number;
   deletions: number;


### PR DESCRIPTION
## Summary
- show list of reviewer names instead of count
- link reviewers to their GitHub profiles
- adjust tests for new reviewer field
- update README wording

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68506b083734832cad9e01ea3507fe63