### PR TITLE
Center login page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ export default function App() {
   return (
     <Box bg="canvas.default" minHeight="100vh">
       {token && <Header />}
-      <Box p={3}>
+      <Box p={token ? 3 : 0}>
         <Routes>
           <Route path="/" element={!token ? <Login /> : <MetricsTable />} />
           <Route

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -37,8 +37,12 @@ export default function Header() {
       borderColor="border.default"
       sx={{ bg: 'canvas.subtle' }}
     >
-      <Box display="flex" alignItems="center" sx={{ gap: 2 }}>
-        <TriangleUpIcon size={24} fill="blue" />
+      <Box
+        display="flex"
+        alignItems="center"
+        sx={{ gap: 2, color: 'accent.fg' }}
+      >
+        <TriangleUpIcon size={24} />
         <Text fontWeight="bold">PR-ism</Text>
       </Box>
       {user && (

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -8,7 +8,7 @@ import {
   FormControl,
   Link,
 } from '@primer/react';
-import { SignInIcon } from '@primer/octicons-react';
+import { SignInIcon, TriangleUpIcon } from '@primer/octicons-react';
 
 import { useAuth } from './AuthContext';
 
@@ -44,7 +44,14 @@ export default function Login() {
         }}
       >
         <Box as="form" onSubmit={handleSubmit}>
-          <Heading as="h1" sx={{ textAlign: 'center', mb: 3 }}>
+          <Heading
+            as="h1"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            sx={{ gap: 2, textAlign: 'center', mb: 3, color: 'accent.fg' }}
+          >
+            <TriangleUpIcon size={24} />
             PR-ism
           </Heading>
           <FormControl>

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -28,7 +28,7 @@ export default function Login() {
       display="flex"
       justifyContent="center"
       alignItems="center"
-      height="100%"
+      minHeight="100vh"
     >
       <Box
         sx={{
@@ -102,6 +102,7 @@ export default function Login() {
           </FormControl>
           <Button
             type="submit"
+            variant="primary"
             leadingIcon={SignInIcon}
             sx={{ width: '100%', mt: 3 }}
           >


### PR DESCRIPTION
## Summary
- adjust the top-level container padding based on auth state
- center the Login box across the full viewport
- switch login button to Primer primary style

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850739b718c832c90b5dcbcd3d42dbe