### PR TITLE
Improve login flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,9 +32,8 @@ export default function App() {
           <Route
             path="/"
             element={
-              token ? <MetricsTable /> : <Navigate to="/login" replace />
+              token ? <Home /> : <Navigate to="/login" replace />
             }
-          <Route path="/" element={!token ? <Login /> : <Home />} />
           <Route
             path="/insights"
             element={token ? <MetricsPage /> : <Navigate to="/" replace />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,11 +15,23 @@ export default function App() {
       {token && <Header />}
       <Box p={token ? 3 : 0}>
         <Routes>
-          <Route path="/" element={!token ? <Login /> : <MetricsTable />} />
+          <Route
+            path="/login"
+            element={token ? <Navigate to="/" replace /> : <Login />}
+          />
+          <Route
+            path="/"
+            element={
+              token ? <MetricsTable /> : <Navigate to="/login" replace />
+            }
+          />
           <Route
             path="/pr/:owner/:repo/:number"
-            element={token ? <PullRequestPage /> : <Navigate to="/" replace />}
+            element={
+              token ? <PullRequestPage /> : <Navigate to="/login" replace />
+            }
           />
+          <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </Box>
     </Box>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ export default function App() {
             element={
               token ? <Home /> : <Navigate to="/login" replace />
             }
+          />
           <Route
             path="/insights"
             element={token ? <MetricsPage /> : <Navigate to="/" replace />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,9 +31,7 @@ export default function App() {
           />
           <Route
             path="/"
-            element={
-              token ? <Home /> : <Navigate to="/login" replace />
-            }
+            element={token ? <Home /> : <Navigate to="/login" replace />}
           />
           <Route
             path="/insights"

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext } from 'react';
+import React, { createContext, useState, useContext, useEffect } from 'react';
 
 interface AuthContextValue {
   token: string | null;
@@ -12,8 +12,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [token, setToken] = useState<string | null>(null);
-  const login = (newToken: string) => setToken(newToken);
-  const logout = () => setToken(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('token');
+    if (stored) setToken(stored);
+  }, []);
+
+  const login = (newToken: string) => {
+    localStorage.setItem('token', newToken);
+    setToken(newToken);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+  };
 
   return (
     <AuthContext.Provider value={{ token, login, logout }}>

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -10,16 +10,26 @@ import {
 } from '@primer/react';
 import { SignInIcon, TriangleUpIcon } from '@primer/octicons-react';
 
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from './AuthContext';
+import { validateToken } from './services/auth';
 
 export default function Login() {
   const { login } = useAuth();
+  const navigate = useNavigate();
   const [value, setValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (value) {
+    if (!value) return;
+
+    try {
+      await validateToken(value.trim());
       login(value.trim());
+      navigate('/');
+    } catch {
+      setError('Invalid token. Please check and try again.');
     }
   };
 
@@ -115,6 +125,11 @@ export default function Login() {
           >
             Sign in
           </Button>
+          {error && (
+            <Text color="danger.fg" mt={2} display="block" textAlign="center">
+              {error}
+            </Text>
+          )}
         </Box>
       </Box>
     </Box>

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -14,6 +14,7 @@ beforeEach(() => {
     items: [],
     loading: false,
   });
+  localStorage.clear();
 });
 
 test('shows login when not authenticated', () => {

--- a/src/__tests__/AuthContext.test.tsx
+++ b/src/__tests__/AuthContext.test.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import { renderHook, act } from '@testing-library/react';
 import { AuthProvider, useAuth } from '../AuthContext';
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 test('login and logout updates token', () => {
   const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     <AuthProvider>{children}</AuthProvider>

--- a/src/__tests__/Login.test.tsx
+++ b/src/__tests__/Login.test.tsx
@@ -3,8 +3,17 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Login from '../Login';
 import { AuthProvider, useAuth } from '../AuthContext';
+import { MemoryRouter } from 'react-router-dom';
+import * as authService from '../services/auth';
+
+jest.mock('../services/auth');
 
 test('login submits provided token', async () => {
+  (authService.validateToken as jest.Mock).mockResolvedValue({
+    login: 'me',
+    avatar_url: 'img',
+  });
+
   let ctx: ReturnType<typeof useAuth> | undefined;
   function Wrapper() {
     ctx = useAuth();
@@ -12,7 +21,9 @@ test('login submits provided token', async () => {
   }
   render(
     <AuthProvider>
-      <Wrapper />
+      <MemoryRouter>
+        <Wrapper />
+      </MemoryRouter>
     </AuthProvider>
   );
   const input = screen.getByPlaceholderText(/github token/i);
@@ -20,4 +31,23 @@ test('login submits provided token', async () => {
   await user.type(input, 'token123');
   await user.click(screen.getByRole('button', { name: /sign in/i }));
   await waitFor(() => expect(ctx!.token).toBe('token123'));
+});
+
+test('shows error when token is invalid', async () => {
+  (authService.validateToken as jest.Mock).mockRejectedValue(new Error('bad'));
+
+  render(
+    <AuthProvider>
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    </AuthProvider>
+  );
+  const user = userEvent.setup();
+  await user.type(screen.getByPlaceholderText(/github token/i), 'bad');
+  await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+  await waitFor(() =>
+    expect(screen.getByText(/invalid token/i)).toBeInTheDocument()
+  );
 });

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1,0 +1,15 @@
+import { validateToken } from '../services/auth';
+import { Octokit } from '@octokit/rest';
+
+const mockInstance: any = { rest: { users: { getAuthenticated: jest.fn() } } };
+
+jest.mock('@octokit/rest', () => ({ Octokit: jest.fn(() => mockInstance) }));
+
+test('validateToken returns user info', async () => {
+  mockInstance.rest.users.getAuthenticated.mockResolvedValue({
+    data: { login: 'me', avatar_url: 'x' },
+  });
+  const data = await validateToken('tok');
+  expect(Octokit).toHaveBeenCalledWith({ auth: 'tok' });
+  expect(data.login).toBe('me');
+});

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,12 @@
+import { Octokit } from '@octokit/rest';
+
+export interface GitHubUser {
+  login: string;
+  avatar_url: string;
+}
+
+export async function validateToken(token: string): Promise<GitHubUser> {
+  const octokit = new Octokit({ auth: token });
+  const { data } = await octokit.rest.users.getAuthenticated();
+  return data;
+}


### PR DESCRIPTION
## Summary
- store token in localStorage and add login/logout helpers
- create `validateToken` service
- navigate unauthenticated users to `/login`
- validate token on login and show an error message if invalid
- update tests for new login behavior

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685076b3172c832c901eb717407e6a8d