### PR TITLE
Style username in header

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Avatar, Text, Button, Breadcrumbs } from '@primer/react';
 import { Octokit } from '@octokit/rest';
-import { TriangleUpIcon } from '@primer/octicons-react';
+import { TriangleUpIcon, SignOutIcon } from '@primer/octicons-react';
 import { useAuth } from './AuthContext';
 
 interface GitHubUser {
@@ -55,8 +55,12 @@ export default function Header({ breadcrumb }: HeaderProps) {
       {user && (
         <Box display="flex" alignItems="center" sx={{ gap: 2 }}>
           <Avatar src={user.avatar_url} size={24} />
-          <Text>{user.login}</Text>
-          <Button onClick={logout}>Logout</Button>
+          <Text fontSize={1} sx={{ fontFamily: 'mono' }}>
+            {user.login}
+          </Text>
+          <Button onClick={logout} trailingIcon={SignOutIcon}>
+            Sign out
+          </Button>
         </Box>
       )}
     </Box>

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -120,7 +120,7 @@ export default function Login() {
           <Button
             type="submit"
             variant="primary"
-            leadingIcon={SignInIcon}
+            trailingIcon={SignInIcon}
             sx={{ width: '100%', mt: 3 }}
           >
             Sign in


### PR DESCRIPTION
## Summary
- style username in the Header with a monospace font and size matching breadcrumbs
- add Sign out icon/button in Header
- move Sign in icon to trailing position
- fix sign out icon placement

## Testing
- `npm run lint`
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851303b087c832c8f345c91294bb918