### PR TITLE
Normalize developer metrics to scores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .DS_Store
 .vscode
 .env
+build
+coverage

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The user interface relies on [Primer](https://primer.style) to match the look an
   - [Development](#development)
   - [Testing](#testing)
   - [Production build](#production-build)
+- [Developer Metrics](#developer-metrics)
 - [License](#license)
 
 ## Features
@@ -82,6 +83,19 @@ npm run build
 ```
 
 The compiled files will be available in the `build/` directory.
+
+## Developer Metrics
+
+The radar chart on the developer page visualizes seven scores scaled from 0 to 10.
+Higher numbers indicate better performance:
+
+- **Merge Success** – ratio of merged pull requests.
+- **Cycle Efficiency** – fewer review cycles yield a higher score.
+- **Size Efficiency** – smaller pull requests score higher.
+- **Lead Time** – quicker merges improve the score.
+- **Review Activity** – how many pull requests the developer reviewed.
+- **Feedback Score** – average number of comments per pull request.
+- **Issue Resolution** – number of issues closed via pull requests.
 
 ## License
 

--- a/src/DeveloperMetricsPage.tsx
+++ b/src/DeveloperMetricsPage.tsx
@@ -164,8 +164,8 @@ export default function DeveloperMetricsPage() {
               />
               <Radar
                 dataKey="value"
-                stroke="var(--color-fg-default)"
-                fill="var(--color-fg-default)"
+                stroke="#2da44e"
+                fill="#2da44e"
                 fillOpacity={0.6}
               />
             </RadarChart>

--- a/src/DeveloperMetricsPage.tsx
+++ b/src/DeveloperMetricsPage.tsx
@@ -60,13 +60,13 @@ export default function DeveloperMetricsPage() {
 
   const chartData = data
     ? [
-        { metric: 'Acceptance Rate', value: data.acceptanceRate },
-        { metric: 'Review Cycles', value: data.reviewCycles },
-        { metric: 'PR Size', value: data.prSize },
-        { metric: 'Lead Time', value: data.leadTime },
-        { metric: 'Reviews', value: data.reviewParticipation },
-        { metric: 'Feedback', value: data.feedbackThoroughness },
-        { metric: 'Issues Closed', value: data.issuesClosed },
+        { metric: 'Merge Success', value: data.mergeSuccess },
+        { metric: 'Cycle Efficiency', value: data.cycleEfficiency },
+        { metric: 'Size Efficiency', value: data.sizeEfficiency },
+        { metric: 'Lead Time', value: data.leadTimeScore },
+        { metric: 'Review Activity', value: data.reviewActivity },
+        { metric: 'Feedback Score', value: data.feedbackScore },
+        { metric: 'Issue Resolution', value: data.issueResolution },
       ]
     : [];
 

--- a/src/DeveloperMetricsPage.tsx
+++ b/src/DeveloperMetricsPage.tsx
@@ -8,13 +8,7 @@ import {
   Text,
   Link,
 } from '@primer/react';
-import {
-  RadarChart,
-  Radar,
-  PolarGrid,
-  PolarAngleAxis,
-  PolarRadiusAxis,
-} from 'recharts';
+import { RadarChart, Radar, PolarAngleAxis, PolarRadiusAxis } from 'recharts';
 import { useAuth } from './AuthContext';
 import { searchUsers } from './services/github';
 import { useDeveloperMetrics } from './hooks/useDeveloperMetrics';
@@ -164,9 +158,13 @@ export default function DeveloperMetricsPage() {
             sx={{ animation: 'fadeInUp 0.3s ease-out' }}
           >
             <RadarChart width={500} height={400} data={chartData}>
-              <PolarGrid />
-              <PolarAngleAxis dataKey="metric" />
-              <PolarRadiusAxis />
+              <PolarAngleAxis
+                dataKey="metric"
+                tick={{ fontFamily: 'monospace', fontSize: 10 }}
+              />
+              <PolarRadiusAxis
+                tick={{ fontFamily: 'monospace', fontSize: 10 }}
+              />
               <Radar
                 dataKey="value"
                 stroke="var(--color-accent-fg)"

--- a/src/DeveloperMetricsPage.tsx
+++ b/src/DeveloperMetricsPage.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   Link,
 } from '@primer/react';
-import { RadarChart, Radar, PolarAngleAxis, PolarRadiusAxis } from 'recharts';
+import { RadarChart, Radar, PolarAngleAxis } from 'recharts';
 import { useAuth } from './AuthContext';
 import { searchUsers } from './services/github';
 import { useDeveloperMetrics } from './hooks/useDeveloperMetrics';
@@ -162,13 +162,10 @@ export default function DeveloperMetricsPage() {
                 dataKey="metric"
                 tick={{ fontFamily: 'monospace', fontSize: 10 }}
               />
-              <PolarRadiusAxis
-                tick={{ fontFamily: 'monospace', fontSize: 10 }}
-              />
               <Radar
                 dataKey="value"
-                stroke="var(--color-accent-fg)"
-                fill="var(--color-accent-subtle)"
+                stroke="var(--color-fg-default)"
+                fill="var(--color-fg-default)"
                 fillOpacity={0.6}
               />
             </RadarChart>

--- a/src/__tests__/useDeveloperMetrics.test.ts
+++ b/src/__tests__/useDeveloperMetrics.test.ts
@@ -13,13 +13,13 @@ const sample = {
   followers: 10,
   following: 5,
   public_repos: 3,
-  acceptanceRate: 50,
-  reviewCycles: 1,
-  prSize: 10,
-  leadTime: 5,
-  reviewParticipation: 3,
-  feedbackThoroughness: 2,
-  issuesClosed: 1,
+  mergeSuccess: 5,
+  cycleEfficiency: 8,
+  sizeEfficiency: 9,
+  leadTimeScore: 7,
+  reviewActivity: 3,
+  feedbackScore: 2,
+  issueResolution: 1,
 };
 
 jest.spyOn(github, 'fetchDeveloperMetrics').mockResolvedValue(sample as any);

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -126,13 +126,13 @@ export interface DeveloperMetrics {
   followers: number;
   following: number;
   public_repos: number;
-  acceptanceRate: number;
-  reviewCycles: number;
-  prSize: number;
-  leadTime: number;
-  reviewParticipation: number;
-  feedbackThoroughness: number;
-  issuesClosed: number;
+  mergeSuccess: number;
+  cycleEfficiency: number;
+  sizeEfficiency: number;
+  leadTimeScore: number;
+  reviewActivity: number;
+  feedbackScore: number;
+  issueResolution: number;
 }
 
 export async function searchUsers(token: string, query: string) {
@@ -215,6 +215,18 @@ export async function fetchDeveloperMetrics(
   const average = (arr: number[]) =>
     arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : 0;
 
+  const round = (n: number) => Math.round(n * 100) / 100;
+
+  const mergeSuccess = authored.data.items.length
+    ? (merged / authored.data.items.length) * 10
+    : 0;
+  const cycleEfficiency = Math.max(0, 10 - average(changes) * 2);
+  const sizeEfficiency = Math.max(0, 10 - median(sizes) / 100);
+  const leadTimeScore = Math.max(0, 10 - median(leadTimes) / 12);
+  const reviewActivity = Math.min(10, reviewed.data.items.length);
+  const feedbackScore = Math.min(10, average(comments));
+  const issueResolution = Math.min(10, issuesClosed);
+
   return {
     login: user.login,
     name: user.name,
@@ -226,14 +238,12 @@ export async function fetchDeveloperMetrics(
     followers: user.followers,
     following: user.following,
     public_repos: user.public_repos,
-    acceptanceRate: authored.data.items.length
-      ? (merged / authored.data.items.length) * 100
-      : 0,
-    reviewCycles: average(changes),
-    prSize: median(sizes),
-    leadTime: median(leadTimes),
-    reviewParticipation: reviewed.data.items.length,
-    feedbackThoroughness: average(comments),
-    issuesClosed,
+    mergeSuccess: round(mergeSuccess),
+    cycleEfficiency: round(cycleEfficiency),
+    sizeEfficiency: round(sizeEfficiency),
+    leadTimeScore: round(leadTimeScore),
+    reviewActivity: round(reviewActivity),
+    feedbackScore: round(feedbackScore),
+    issueResolution: round(issueResolution),
   };
 }


### PR DESCRIPTION
## Summary
- normalize developer metrics to a 0-10 scale
- rename developer metric fields
- update radar chart to use the new scores
- document developer metric meaning in README
- adjust developer metrics unit test

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685142799184832cb8dc713bd74cfd0d