### PR TITLE
Modernize developer insights page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ The user interface relies on [Primer](https://primer.style) to match the look an
   - [Development](#development)
   - [Testing](#testing)
   - [Production build](#production-build)
-- [Developer Metrics](#developer-metrics)
-- [License](#license)
+- [Developer insights](#developer-insights)
+  - [License](#license)
 
 ## Features
 
 - Authenticate with a personal access token.
 - View pull requests you authored or reviewed.
 - Metrics for draft time, first review and total lifespan.
- - Display reviewer names with links and change requests.
+- Display reviewer names with links and change requests.
 - Filter by repository and author.
 - Direct links to each pull request.
 
@@ -84,7 +84,7 @@ npm run build
 
 The compiled files will be available in the `build/` directory.
 
-## Developer Metrics
+## Developer insights
 
 The radar chart on the developer page visualizes seven scores scaled from 0 to 10.
 Higher numbers indicate better performance:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,10 +16,11 @@ export default function App() {
   let breadcrumb: string | undefined;
   if (
     location.pathname.startsWith('/insights') ||
-    location.pathname.startsWith('/pr') ||
-    location.pathname.startsWith('/developer')
+    location.pathname.startsWith('/pr')
   ) {
     breadcrumb = 'Pull request insights';
+  } else if (location.pathname.startsWith('/developer')) {
+    breadcrumb = 'Developer insights';
   }
 
   return (

--- a/src/DeveloperMetricsPage.tsx
+++ b/src/DeveloperMetricsPage.tsx
@@ -72,6 +72,14 @@ export default function DeveloperMetricsPage() {
   );
 
   useEffect(() => {
+    const prev = document.title;
+    document.title = 'Developer insights';
+    return () => {
+      document.title = prev;
+    };
+  }, []);
+
+  useEffect(() => {
     if (!debouncedQuery) {
       setOptions([]);
       return;
@@ -111,40 +119,52 @@ export default function DeveloperMetricsPage() {
 
   return (
     <Box p={3}>
-      <Box mb={3} position="relative" maxWidth={300}>
-        <TextInput
-          placeholder="Search GitHub user"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          sx={{ width: '100%' }}
-        />
-        {options.length > 0 && (
-          <Box
-            position="absolute"
-            width="100%"
-            borderWidth={1}
-            borderStyle="solid"
-            borderColor="border.default"
-            borderRadius={2}
-            bg="canvas.overlay"
-            mt={1}
-            zIndex={1}
-          >
-            {options.map((u) => (
-              <Box
-                key={u.login}
-                p={2}
-                display="flex"
-                alignItems="center"
-                sx={{ cursor: 'pointer', '&:hover': { bg: 'neutral.muted' } }}
-                onClick={() => handleSelect(u)}
-              >
-                <Avatar src={u.avatar_url} size={20} mr={2} />
-                <Text>{u.login}</Text>
-              </Box>
-            ))}
-          </Box>
-        )}
+      <Box
+        mb={3}
+        display="flex"
+        alignItems="center"
+        justifyContent="space-between"
+        flexWrap="wrap"
+        sx={{ gap: 3 }}
+      >
+        <Heading as="h2" sx={{ fontSize: 4 }}>
+          Developer insights
+        </Heading>
+        <Box position="relative" width="100%" maxWidth={300}>
+          <TextInput
+            placeholder="Search GitHub user"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            sx={{ width: '100%' }}
+          />
+          {options.length > 0 && (
+            <Box
+              position="absolute"
+              width="100%"
+              borderWidth={1}
+              borderStyle="solid"
+              borderColor="border.default"
+              borderRadius={2}
+              bg="canvas.overlay"
+              mt={1}
+              zIndex={1}
+            >
+              {options.map((u) => (
+                <Box
+                  key={u.login}
+                  p={2}
+                  display="flex"
+                  alignItems="center"
+                  sx={{ cursor: 'pointer', '&:hover': { bg: 'neutral.muted' } }}
+                  onClick={() => handleSelect(u)}
+                >
+                  <Avatar src={u.avatar_url} size={20} mr={2} />
+                  <Text>{u.login}</Text>
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Box>
       </Box>
 
       {loading && (
@@ -155,7 +175,13 @@ export default function DeveloperMetricsPage() {
 
       {data && !loading && (
         <>
-          <Box display="flex" sx={{ gap: 4, flexWrap: 'wrap' }}>
+          <Box
+            display="grid"
+            sx={{
+              gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+              gap: 4,
+            }}
+          >
             <Box
               p={3}
               borderWidth={1}

--- a/src/__tests__/DeveloperMetricsPage.test.tsx
+++ b/src/__tests__/DeveloperMetricsPage.test.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DeveloperMetricsPage from '../DeveloperMetricsPage';
+import { AuthProvider, useAuth } from '../AuthContext';
+import * as metricsHook from '../hooks/useDeveloperMetrics';
+
+jest.mock('../hooks/useDeveloperMetrics');
+
+function Wrapper() {
+  const auth = useAuth();
+  useEffect(() => {
+    auth.login('tok');
+  }, [auth]);
+  return (
+    <MemoryRouter>
+      <DeveloperMetricsPage />
+    </MemoryRouter>
+  );
+}
+
+test('renders page heading', () => {
+  (metricsHook.useDeveloperMetrics as jest.Mock).mockReturnValue({
+    data: null,
+    loading: false,
+  });
+  render(
+    <AuthProvider>
+      <Wrapper />
+    </AuthProvider>
+  );
+  expect(
+    screen.getByRole('heading', { name: /developer insights/i })
+  ).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- rename Developer Metrics docs section to Developer insights
- update breadcrumb logic for developer page
- modernize layout of DeveloperMetricsPage and set document title
- add tests for DeveloperMetricsPage

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685167985b30832c99ec8ce3c66f273a