### PR TITLE
Enhance developer insights page

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,4 @@ Higher numbers indicate better performance:
 
 This project is released under the [MIT License](LICENSE).
 
-Line coverage: 84.57%
+Line coverage: 74.67%

--- a/src/__tests__/DeveloperMetricsPage.test.tsx
+++ b/src/__tests__/DeveloperMetricsPage.test.tsx
@@ -4,8 +4,10 @@ import { MemoryRouter } from 'react-router-dom';
 import DeveloperMetricsPage from '../DeveloperMetricsPage';
 import { AuthProvider, useAuth } from '../AuthContext';
 import * as metricsHook from '../hooks/useDeveloperMetrics';
+import * as prHook from '../hooks/useUserPullRequests';
 
 jest.mock('../hooks/useDeveloperMetrics');
+jest.mock('../hooks/useUserPullRequests');
 
 function Wrapper() {
   const auth = useAuth();
@@ -24,6 +26,10 @@ test('renders page heading', () => {
     data: null,
     loading: false,
   });
+  (prHook.useUserPullRequests as jest.Mock).mockReturnValue({
+    items: [],
+    loading: false,
+  });
   render(
     <AuthProvider>
       <Wrapper />
@@ -32,4 +38,49 @@ test('renders page heading', () => {
   expect(
     screen.getByRole('heading', { name: /developer insights/i })
   ).toBeInTheDocument();
+});
+
+test('shows metrics table and pull requests', () => {
+  (metricsHook.useDeveloperMetrics as jest.Mock).mockReturnValue({
+    data: {
+      login: 'dev',
+      name: 'Dev',
+      avatar_url: 'a',
+      html_url: 'h',
+      bio: null,
+      company: null,
+      location: null,
+      followers: 0,
+      following: 0,
+      public_repos: 0,
+      mergeSuccess: 1,
+      cycleEfficiency: 2,
+      sizeEfficiency: 3,
+      leadTimeScore: 4,
+      reviewActivity: 5,
+      feedbackScore: 6,
+      issueResolution: 7,
+    },
+    loading: false,
+  });
+  (prHook.useUserPullRequests as jest.Mock).mockReturnValue({
+    items: [
+      {
+        id: 1,
+        title: 't',
+        url: 'u',
+        created_at: '2020',
+        state: 'open',
+        repo: 'r',
+      },
+    ],
+    loading: false,
+  });
+  render(
+    <AuthProvider>
+      <Wrapper />
+    </AuthProvider>
+  );
+  expect(screen.getByText('Org Avg')).toBeInTheDocument();
+  expect(screen.getByText(/recent pull requests/i)).toBeInTheDocument();
 });

--- a/src/__tests__/useUserPullRequests.test.ts
+++ b/src/__tests__/useUserPullRequests.test.ts
@@ -1,0 +1,23 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useUserPullRequests } from '../hooks/useUserPullRequests';
+import * as github from '../services/github';
+
+const sample = [
+  {
+    id: 1,
+    title: 'PR',
+    url: 'u',
+    created_at: '2020-01-01',
+    state: 'open',
+    repo: 'o/r',
+  },
+];
+
+jest.spyOn(github, 'fetchUserPullRequests').mockResolvedValue(sample as any);
+
+test('loads user pull requests', async () => {
+  const { result } = renderHook(() => useUserPullRequests('tok', 'dev'));
+  expect(result.current.loading).toBe(true);
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  expect(result.current.items).toEqual(sample);
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,9 @@
+export const ORG_AVERAGES = {
+  mergeSuccess: 5,
+  cycleEfficiency: 5,
+  sizeEfficiency: 5,
+  leadTimeScore: 5,
+  reviewActivity: 5,
+  feedbackScore: 5,
+  issueResolution: 5,
+};

--- a/src/hooks/useUserPullRequests.ts
+++ b/src/hooks/useUserPullRequests.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { fetchUserPullRequests, DeveloperPR } from '../services/github';
+
+export function useUserPullRequests(token: string, login: string | null) {
+  const [items, setItems] = useState<DeveloperPR[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!login) return;
+    let cancel = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const prs = await fetchUserPullRequests(token, login);
+        if (!cancel) setItems(prs);
+      } catch (err) {
+        if (!cancel) console.error(err);
+      } finally {
+        if (!cancel) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancel = true;
+    };
+  }, [token, login]);
+
+  return { items, loading };
+}

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -247,3 +247,34 @@ export async function fetchDeveloperMetrics(
     issueResolution: round(issueResolution),
   };
 }
+
+export interface DeveloperPR {
+  id: number;
+  title: string;
+  url: string;
+  created_at: string;
+  state: string;
+  repo: string;
+}
+
+export async function fetchUserPullRequests(
+  token: string,
+  login: string,
+  limit = 5
+): Promise<DeveloperPR[]> {
+  const octokit = new Octokit({ auth: token });
+  const { data } = await octokit.rest.search.issuesAndPullRequests({
+    q: `is:pr author:${login}`,
+    sort: 'created',
+    order: 'desc',
+    per_page: limit,
+  });
+  return data.items.map((it: any) => ({
+    id: it.id,
+    title: it.title,
+    url: it.html_url,
+    created_at: it.created_at,
+    state: it.state,
+    repo: it.repository_url.split('/').slice(-2).join('/'),
+  }));
+}


### PR DESCRIPTION
## Summary
- add organization averages constant
- fetch user pull requests and expose hook
- enrich DeveloperMetricsPage with quick links, metric table, recent PRs and timeline
- test new hook and metrics page behavior
- update coverage badge

## Testing
- `npm test`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68518b5e0bd0832c827b72549b34c90d