### PR TITLE
Add Repo Insights section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Home from './Home';
 import Header from './Header';
 import PullRequestPage from './PullRequest';
 import DeveloperMetricsPage from './DeveloperMetricsPage';
+import RepoInsightsPage from './RepoInsightsPage';
 import { useAuth } from './AuthContext';
 
 export default function App() {
@@ -21,6 +22,8 @@ export default function App() {
     breadcrumb = 'Pull request insights';
   } else if (location.pathname.startsWith('/developer')) {
     breadcrumb = 'Developer insights';
+  } else if (location.pathname.startsWith('/repo')) {
+    breadcrumb = 'Repo insights';
   }
 
   return (
@@ -45,6 +48,10 @@ export default function App() {
             element={
               token ? <DeveloperMetricsPage /> : <Navigate to="/" replace />
             }
+          />
+          <Route
+            path="/repo"
+            element={token ? <RepoInsightsPage /> : <Navigate to="/" replace />}
           />
           <Route
             path="/pr/:owner/:repo/:number"

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import { Box, Text } from '@primer/react';
+import {
+  RepoIcon,
+  PeopleIcon,
+  GitPullRequestIcon,
+} from '@primer/octicons-react';
 import { Link as RouterLink } from 'react-router-dom';
 
 export default function Home() {
@@ -22,9 +27,12 @@ export default function Home() {
           '&:hover': { boxShadow: 'shadow.large', textDecoration: 'none' },
         }}
       >
-        <Text fontSize={2} fontWeight="bold">
-          Pull request insights
-        </Text>
+        <Box display="flex" alignItems="center" sx={{ gap: 2 }}>
+          <GitPullRequestIcon />
+          <Text fontSize={2} fontWeight="bold">
+            Pull request insights
+          </Text>
+        </Box>
         <Text as="p" mt={2} color="fg.muted">
           Dive into metrics about your pull requests to track review timelines
           and lead time.
@@ -47,12 +55,42 @@ export default function Home() {
           '&:hover': { boxShadow: 'shadow.large', textDecoration: 'none' },
         }}
       >
-        <Text fontSize={2} fontWeight="bold">
-          Developer PR Metrics Radar
-        </Text>
+        <Box display="flex" alignItems="center" sx={{ gap: 2 }}>
+          <PeopleIcon />
+          <Text fontSize={2} fontWeight="bold">
+            Developer Insights
+          </Text>
+        </Box>
         <Text as="p" mt={2} color="fg.muted">
           Visualize a developer&apos;s contributions and review activities
           across GitHub repositories using insightful radar metrics.
+        </Text>
+      </Box>
+      <Box
+        as={RouterLink}
+        to="/repo"
+        sx={{
+          p: 4,
+          width: '100%',
+          maxWidth: 400,
+          borderWidth: '1px',
+          borderStyle: 'solid',
+          borderColor: 'border.default',
+          borderRadius: 2,
+          boxShadow: 'shadow.medium',
+          textDecoration: 'none',
+          color: 'inherit',
+          '&:hover': { boxShadow: 'shadow.large', textDecoration: 'none' },
+        }}
+      >
+        <Box display="flex" alignItems="center" sx={{ gap: 2 }}>
+          <RepoIcon />
+          <Text fontSize={2} fontWeight="bold">
+            Repo Insights
+          </Text>
+        </Box>
+        <Text as="p" mt={2} color="fg.muted">
+          Explore repository health and DevOps metrics calculated from GitHub.
         </Text>
       </Box>
     </Box>

--- a/src/RepoInsightsPage.tsx
+++ b/src/RepoInsightsPage.tsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useState } from 'react';
+import { Box, TextInput, Button, Heading, Spinner, Text } from '@primer/react';
+import { useAuth } from './AuthContext';
+import { useRepoInsights } from './hooks/useRepoInsights';
+
+export default function RepoInsightsPage() {
+  const { token } = useAuth();
+  const [input, setInput] = useState('');
+  const [owner, setOwner] = useState<string | null>(null);
+  const [repo, setRepo] = useState<string | null>(null);
+  const { data, loading, error } = useRepoInsights(token!, owner, repo);
+  const [loadingMsgIndex, setLoadingMsgIndex] = useState(0);
+  const loadingMessages = [
+    'Fetching repo info...',
+    'Crunching numbers...',
+    'Analyzing pull requests...',
+  ];
+
+  useEffect(() => {
+    const prev = document.title;
+    document.title = 'Repo insights';
+    return () => {
+      document.title = prev;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!loading) return;
+    const id = setInterval(() => {
+      setLoadingMsgIndex((i) => (i + 1) % loadingMessages.length);
+    }, 2000);
+    return () => clearInterval(id);
+  }, [loading, loadingMessages.length]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const pattern = /^(?:https?:\/\/github.com\/)?([^/]+)\/([^/]+)$/i;
+    const match = input.trim().match(pattern);
+    if (match) {
+      setOwner(match[1]);
+      setRepo(match[2]);
+    } else {
+      setOwner(null);
+      setRepo(null);
+      alert('Enter a valid GitHub repo URL like owner/repo');
+    }
+  };
+
+  return (
+    <Box p={3} position="relative">
+      <form onSubmit={handleSubmit}>
+        <Box mb={3} display="flex" sx={{ gap: 2 }}>
+          <TextInput
+            placeholder="owner/repo or URL"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            sx={{ flexGrow: 1 }}
+          />
+          <Button type="submit">Load</Button>
+        </Box>
+      </form>
+
+      {loading && (
+        <Box
+          position="fixed"
+          top={0}
+          left={0}
+          width="100%"
+          height="100%"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          flexDirection="column"
+          sx={{ bg: 'canvas.overlay', opacity: 0.9, zIndex: 10 }}
+        >
+          <Spinner size="large" />
+          <Text
+            mt={2}
+            sx={{
+              fontFamily: 'mono',
+              animation: 'pulse 1.5s ease-in-out infinite',
+            }}
+          >
+            {loadingMessages[loadingMsgIndex]}
+          </Text>
+        </Box>
+      )}
+
+      {error && (
+        <Text color="danger.fg" mb={3} display="block">
+          {error}
+        </Text>
+      )}
+
+      {data && !loading && (
+        <Box
+          display="grid"
+          sx={{
+            gridTemplateColumns: 'repeat(auto-fit,minmax(250px,1fr))',
+            gap: 3,
+          }}
+        >
+          <MetricCard
+            title="Deployment Frequency"
+            value={data.deploymentFrequency}
+          />
+          <MetricCard
+            title="Lead Time for Changes"
+            value={`${data.leadTime.toFixed(2)}h`}
+          />
+          <MetricCard
+            title="Change Failure Rate"
+            value={`${(data.changeFailureRate * 100).toFixed(1)}%`}
+          />
+          <MetricCard
+            title="Mean Time to Restore"
+            value={`${data.meanTimeToRestore.toFixed(2)}h`}
+          />
+          <MetricCard title="Open Issue Count" value={data.openIssues} />
+          <MetricCard
+            title="Open Pull Request Count"
+            value={data.openPullRequests}
+          />
+          <MetricCard
+            title="Average PR Merge Time"
+            value={`${data.averageMergeTime.toFixed(2)}h`}
+          />
+          <MetricCard
+            title="Weekly Commit Activity"
+            value={data.weeklyCommits.join(', ')}
+          />
+          <MetricCard title="Contributor Count" value={data.contributorCount} />
+          <MetricCard
+            title="Community Health Score"
+            value={data.communityHealthScore}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+interface MetricCardProps {
+  title: string;
+  value: React.ReactNode;
+}
+
+function MetricCard({ title, value }: MetricCardProps) {
+  return (
+    <Box
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border.default"
+      borderRadius={2}
+      p={3}
+      boxShadow="shadow.medium"
+    >
+      <Heading as="h3" sx={{ fontSize: 2, mb: 2 }}>
+        {title}
+      </Heading>
+      <Text fontSize={1}>{value}</Text>
+    </Box>
+  );
+}

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -47,7 +47,8 @@ test('shows home card when authenticated', async () => {
     </AuthProvider>
   );
   expect(screen.getByText('Pull request insights')).toBeInTheDocument();
-  expect(screen.getByText('Developer PR Metrics Radar')).toBeInTheDocument();
+  expect(screen.getByText('Developer Insights')).toBeInTheDocument();
+  expect(screen.getByText('Repo Insights')).toBeInTheDocument();
   expect(screen.getByText('PR-ism')).toBeInTheDocument();
 });
 

--- a/src/hooks/useRepoInsights.ts
+++ b/src/hooks/useRepoInsights.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { fetchRepoInsights, RepoInsights } from '../services/github';
+
+export function useRepoInsights(
+  token: string,
+  owner: string | null,
+  repo: string | null
+) {
+  const [data, setData] = useState<RepoInsights | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!owner || !repo) return;
+    let cancel = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetchRepoInsights(token, owner, repo);
+        if (!cancel) setData(res);
+      } catch {
+        if (!cancel) setError('Failed to load data');
+      } finally {
+        if (!cancel) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancel = true;
+    };
+  }, [token, owner, repo]);
+
+  return { data, loading, error };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -16,3 +16,15 @@ body {
     transform: translateY(0);
   }
 }
+
+@keyframes pulse {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+  100% {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- rename Developer PR Metrics card to **Developer Insights** and add icons to home cards
- add new **Repo Insights** card with navigation and metrics
- fetch repository insights via new GitHub service and React hook
- show loading mask with pulsing messages while loading repo data
- expose Repo Insights page route and breadcrumb

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851a1b6f068832c8ba95c0b5cf59fa1