### PR TITLE
Fix breadcrumbs navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,16 +14,16 @@ export default function App() {
   const { token } = useAuth();
   const location = useLocation();
 
-  let breadcrumb: string | undefined;
+  let breadcrumb: { label: string; to: string } | undefined;
   if (
     location.pathname.startsWith('/insights') ||
     location.pathname.startsWith('/pr')
   ) {
-    breadcrumb = 'Pull request insights';
+    breadcrumb = { label: 'Pull request insights', to: '/insights' };
   } else if (location.pathname.startsWith('/developer')) {
-    breadcrumb = 'Developer insights';
+    breadcrumb = { label: 'Developer insights', to: '/developer' };
   } else if (location.pathname.startsWith('/repo')) {
-    breadcrumb = 'Repo insights';
+    breadcrumb = { label: 'Repo insights', to: '/repo' };
   }
 
   return (

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Box, Avatar, Text, Button, Breadcrumbs } from '@primer/react';
 import { Octokit } from '@octokit/rest';
 import { TriangleUpIcon, SignOutIcon } from '@primer/octicons-react';
+import { Link as RouterLink } from 'react-router-dom';
 import { useAuth } from './AuthContext';
 
 interface GitHubUser {
@@ -9,8 +10,13 @@ interface GitHubUser {
   avatar_url: string;
 }
 
+interface BreadcrumbItem {
+  label: string;
+  to: string;
+}
+
 interface HeaderProps {
-  breadcrumb?: string;
+  breadcrumb?: BreadcrumbItem;
 }
 
 export default function Header({ breadcrumb }: HeaderProps) {
@@ -48,8 +54,14 @@ export default function Header({ breadcrumb }: HeaderProps) {
       >
         <TriangleUpIcon size={24} fill="blue" />
         <Breadcrumbs sx={{ fontWeight: 'bold' }}>
-          <Breadcrumbs.Item to="/">PR-ism</Breadcrumbs.Item>
-          {breadcrumb && <Breadcrumbs.Item>{breadcrumb}</Breadcrumbs.Item>}
+          <Breadcrumbs.Item as={RouterLink} to="/">
+            PR-ism
+          </Breadcrumbs.Item>
+          {breadcrumb && (
+            <Breadcrumbs.Item as={RouterLink} to={breadcrumb.to}>
+              {breadcrumb.label}
+            </Breadcrumbs.Item>
+          )}
         </Breadcrumbs>
       </Box>
       {user && (

--- a/src/__tests__/Header.test.tsx
+++ b/src/__tests__/Header.test.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import Header from '../Header';
 import { AuthProvider, useAuth } from '../AuthContext';
+import { MemoryRouter } from 'react-router-dom';
 import { Octokit } from '@octokit/rest';
 
 jest.mock('@octokit/rest');
@@ -20,7 +21,13 @@ test('fetches and displays user info', async () => {
     useEffect(() => {
       auth.login('token');
     }, [auth]);
-    return <Header breadcrumb="Pull request insights" />;
+    return (
+      <MemoryRouter>
+        <Header
+          breadcrumb={{ label: 'Pull request insights', to: '/insights' }}
+        />
+      </MemoryRouter>
+    );
   }
 
   render(
@@ -31,5 +38,6 @@ test('fetches and displays user info', async () => {
 
   await waitFor(() => expect(screen.getByText('octo')).toBeInTheDocument());
   expect(Octokit).toHaveBeenCalledWith({ auth: 'token' });
-  expect(screen.getByText('Pull request insights')).toBeInTheDocument();
+  const link = screen.getByRole('link', { name: 'Pull request insights' });
+  expect(link).toHaveAttribute('href', '/insights');
 });


### PR DESCRIPTION
## Summary
- make breadcrumb links use RouterLink so they navigate properly
- supply page URLs in breadcrumb prop
- update unit tests for breadcrumb link behavior

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851a85d233c832c84a038db02a49b25