### PR TITLE
Improve component structure and tests

### DIFF
--- a/src/DeveloperMetricCard.tsx
+++ b/src/DeveloperMetricCard.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Box, Heading, Text, Label } from '@primer/react';
+
+interface Props {
+  name: string;
+  brief: string;
+  details: string;
+  valueDesc: string;
+  score: number | null;
+  value: number;
+  format?: (n: number) => string;
+}
+
+export default function DeveloperMetricCard({
+  name,
+  brief,
+  details,
+  valueDesc,
+  score,
+  value,
+  format,
+}: Props) {
+  const variant =
+    score === null
+      ? 'default'
+      : score < 3
+        ? 'danger'
+        : score <= 8
+          ? 'attention'
+          : 'success';
+  return (
+    <Box
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border.default"
+      borderRadius={2}
+      p={2}
+    >
+      <Heading
+        as="h3"
+        sx={{
+          fontSize: 1,
+          mb: 1,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        {name}
+        {typeof score === 'number' && (
+          <Label variant={variant} size="small">
+            {score}
+          </Label>
+        )}
+      </Heading>
+      <Text sx={{ fontSize: 1 }}>{brief}</Text>
+      <Text as="p" sx={{ mt: 1, color: 'fg.muted', fontSize: 0 }}>
+        {details}
+      </Text>
+      <Text as="p" sx={{ mt: 1, fontSize: 0 }}>
+        <Label variant={variant} size="small" mr={1}>
+          {format ? format(value) : value}
+        </Label>{' '}
+        {valueDesc}
+      </Text>
+    </Box>
+  );
+}

--- a/src/DeveloperMetricsPage.tsx
+++ b/src/DeveloperMetricsPage.tsx
@@ -1,13 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import {
-  Box,
-  TextInput,
-  Avatar,
-  Heading,
-  Text,
-  Link,
-  Label,
-} from '@primer/react';
+import { Box, Avatar, Heading, Text, Link } from '@primer/react';
 import { RadarChart, Radar, PolarAngleAxis } from 'recharts';
 import { useAuth } from './AuthContext';
 import { searchUsers } from './services/github';
@@ -15,6 +7,8 @@ import { useDeveloperMetrics } from './hooks/useDeveloperMetrics';
 import { useDebounce } from './hooks/useDebounce';
 import { GitHubUser } from './services/auth';
 import LoadingOverlay from './LoadingOverlay';
+import SearchUserBox from './SearchUserBox';
+import DeveloperMetricCard from './DeveloperMetricCard';
 
 const METRIC_INFO = [
   {
@@ -152,41 +146,12 @@ export default function DeveloperMetricsPage() {
         <Heading as="h2" sx={{ fontSize: 4 }}>
           Developer insights
         </Heading>
-        <Box position="relative" width="100%" maxWidth={300}>
-          <TextInput
-            placeholder="Search GitHub user"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            sx={{ width: '100%' }}
-          />
-          {options.length > 0 && (
-            <Box
-              position="absolute"
-              width="100%"
-              borderWidth={1}
-              borderStyle="solid"
-              borderColor="border.default"
-              borderRadius={2}
-              bg="canvas.overlay"
-              mt={1}
-              zIndex={1}
-            >
-              {options.map((u) => (
-                <Box
-                  key={u.login}
-                  p={2}
-                  display="flex"
-                  alignItems="center"
-                  sx={{ cursor: 'pointer', '&:hover': { bg: 'neutral.muted' } }}
-                  onClick={() => handleSelect(u)}
-                >
-                  <Avatar src={u.avatar_url} size={20} mr={2} />
-                  <Text>{u.login}</Text>
-                </Box>
-              ))}
-            </Box>
-          )}
-        </Box>
+        <SearchUserBox
+          query={query}
+          options={options}
+          onQueryChange={setQuery}
+          onSelect={handleSelect}
+        />
       </Box>
 
       <LoadingOverlay show={loading} messages={loadingMessages} />
@@ -269,61 +234,20 @@ export default function DeveloperMetricsPage() {
                 gap: 3,
               }}
             >
-              {METRIC_INFO.map((info) => {
-                const score = data
-                  ? (data as any)[info.key as keyof typeof data]
-                  : null;
-                const variant =
-                  score === null
-                    ? 'default'
-                    : score < 3
-                      ? 'danger'
-                      : score <= 8
-                        ? 'attention'
-                        : 'success';
-                return (
-                  <Box
-                    key={info.name}
-                    borderWidth={1}
-                    borderStyle="solid"
-                    borderColor="border.default"
-                    borderRadius={2}
-                    p={2}
-                  >
-                    <Heading
-                      as="h3"
-                      sx={{
-                        fontSize: 1,
-                        mb: 1,
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                      }}
-                    >
-                      {info.name}
-                      {typeof score === 'number' && (
-                        <Label variant={variant} size="small">
-                          {score}
-                        </Label>
-                      )}
-                    </Heading>
-                    <Text sx={{ fontSize: 1 }}>{info.brief}</Text>
-                    <Text as="p" sx={{ mt: 1, color: 'fg.muted', fontSize: 0 }}>
-                      {info.details}
-                    </Text>
-                    {data && (
-                      <Text as="p" sx={{ mt: 1, fontSize: 0 }}>
-                        <Label variant={variant} size="small" mr={1}>
-                          {info.format
-                            ? info.format((data as any)[info.valueKey])
-                            : (data as any)[info.valueKey]}
-                        </Label>{' '}
-                        {info.valueDesc}
-                      </Text>
-                    )}
-                  </Box>
-                );
-              })}
+              {METRIC_INFO.map((info) => (
+                <DeveloperMetricCard
+                  key={info.name}
+                  name={info.name}
+                  brief={info.brief}
+                  details={info.details}
+                  valueDesc={info.valueDesc}
+                  score={
+                    data ? (data as any)[info.key as keyof typeof data] : null
+                  }
+                  value={data ? (data as any)[info.valueKey] : 0}
+                  format={info.format}
+                />
+              ))}
             </Box>
           </Box>
         </>

--- a/src/SearchUserBox.tsx
+++ b/src/SearchUserBox.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Box, TextInput, Avatar, Text } from '@primer/react';
+import { GitHubUser } from './services/auth';
+
+interface Props {
+  query: string;
+  options: GitHubUser[];
+  onQueryChange: (value: string) => void;
+  onSelect: (user: GitHubUser) => void;
+}
+
+export default function SearchUserBox({
+  query,
+  options,
+  onQueryChange,
+  onSelect,
+}: Props) {
+  return (
+    <Box position="relative" width="100%" maxWidth={300}>
+      <TextInput
+        placeholder="Search GitHub user"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        sx={{ width: '100%' }}
+      />
+      {options.length > 0 && (
+        <Box
+          position="absolute"
+          width="100%"
+          borderWidth={1}
+          borderStyle="solid"
+          borderColor="border.default"
+          borderRadius={2}
+          bg="canvas.overlay"
+          mt={1}
+          zIndex={1}
+        >
+          {options.map((u) => (
+            <Box
+              key={u.login}
+              p={2}
+              display="flex"
+              alignItems="center"
+              sx={{ cursor: 'pointer', '&:hover': { bg: 'neutral.muted' } }}
+              onClick={() => onSelect(u)}
+            >
+              <Avatar src={u.avatar_url} size={20} mr={2} />
+              <Text>{u.login}</Text>
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/__tests__/DeveloperMetricCard.test.tsx
+++ b/src/__tests__/DeveloperMetricCard.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DeveloperMetricCard from '../DeveloperMetricCard';
+
+test('renders metric info and value', () => {
+  render(
+    <DeveloperMetricCard
+      name="Merge Success"
+      brief="brief"
+      details="details"
+      valueDesc="merged"
+      score={5}
+      value={0.5}
+      format={(n) => `${n * 100}%`}
+    />
+  );
+  expect(screen.getByText('Merge Success')).toBeInTheDocument();
+  expect(screen.getByText('brief')).toBeInTheDocument();
+  expect(screen.getByText('details')).toBeInTheDocument();
+  expect(screen.getByText('50%')).toBeInTheDocument();
+});

--- a/src/__tests__/DeveloperMetricsPage.test.tsx
+++ b/src/__tests__/DeveloperMetricsPage.test.tsx
@@ -1,11 +1,14 @@
 import React, { useEffect } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import DeveloperMetricsPage from '../DeveloperMetricsPage';
 import { AuthProvider, useAuth } from '../AuthContext';
 import * as metricsHook from '../hooks/useDeveloperMetrics';
+import * as github from '../services/github';
 
 jest.mock('../hooks/useDeveloperMetrics');
+jest.mock('../services/github');
 
 function Wrapper() {
   const auth = useAuth();
@@ -32,4 +35,44 @@ test('renders page heading', () => {
   expect(
     screen.getByRole('heading', { name: /developer insights/i })
   ).toBeInTheDocument();
+});
+
+test('displays suggestions and handles selection', async () => {
+  (metricsHook.useDeveloperMetrics as jest.Mock).mockReturnValue({
+    data: null,
+    loading: false,
+  });
+  (github.searchUsers as jest.Mock).mockResolvedValue([
+    { login: 'octo', avatar_url: 'x' },
+  ]);
+  render(
+    <AuthProvider>
+      <Wrapper />
+    </AuthProvider>
+  );
+  const user = userEvent.setup();
+  await user.type(screen.getByPlaceholderText(/search github user/i), 'oct');
+  await waitFor(() => expect(github.searchUsers).toHaveBeenCalled());
+  await waitFor(() => screen.getByText('octo'));
+  await user.click(screen.getByText('octo'));
+  expect(screen.queryByText('octo')).not.toBeInTheDocument();
+});
+
+test('logs error on search failure', async () => {
+  (metricsHook.useDeveloperMetrics as jest.Mock).mockReturnValue({
+    data: null,
+    loading: false,
+  });
+  (github.searchUsers as jest.Mock).mockRejectedValue(new Error('fail'));
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  render(
+    <AuthProvider>
+      <Wrapper />
+    </AuthProvider>
+  );
+  const user = userEvent.setup();
+  await user.type(screen.getByPlaceholderText(/search github user/i), 'oct');
+  await waitFor(() => expect(github.searchUsers).toHaveBeenCalled());
+  await waitFor(() => expect(spy).toHaveBeenCalled());
+  spy.mockRestore();
 });

--- a/src/__tests__/SearchUserBox.test.tsx
+++ b/src/__tests__/SearchUserBox.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SearchUserBox from '../SearchUserBox';
+import { GitHubUser } from '../services/auth';
+
+const sample: GitHubUser[] = [{ login: 'octo', avatar_url: 'x' }];
+
+test('calls handlers when selecting user', async () => {
+  const handleQuery = jest.fn();
+  const handleSelect = jest.fn();
+  render(
+    <SearchUserBox
+      query="oc"
+      options={sample}
+      onQueryChange={handleQuery}
+      onSelect={handleSelect}
+    />
+  );
+  const user = userEvent.setup();
+  await user.type(screen.getByPlaceholderText(/search github user/i), 't');
+  expect(handleQuery).toHaveBeenCalledWith('oct');
+  await user.click(screen.getByText('octo'));
+  expect(handleSelect).toHaveBeenCalledWith(sample[0]);
+});

--- a/src/__tests__/searchUsers.test.ts
+++ b/src/__tests__/searchUsers.test.ts
@@ -1,0 +1,15 @@
+import { searchUsers } from '../services/github';
+import { Octokit } from '@octokit/rest';
+
+const mockInstance: any = { rest: { search: { users: jest.fn() } } };
+
+jest.mock('@octokit/rest', () => ({ Octokit: jest.fn(() => mockInstance) }));
+
+test('searchUsers returns simplified results', async () => {
+  (mockInstance.rest.search.users as jest.Mock).mockResolvedValue({
+    data: { items: [{ login: 'me', avatar_url: 'x' }] },
+  });
+  const res = await searchUsers('tok', 'me');
+  expect(Octokit).toHaveBeenCalledWith({ auth: 'tok' });
+  expect(res[0].login).toBe('me');
+});


### PR DESCRIPTION
## Summary
- split search box and metric card into their own components
- refactor DeveloperMetricsPage to use the new components
- add unit tests for SearchUserBox, DeveloperMetricCard, DeveloperMetricsPage and github searchUsers

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851aaba6320832c8da164ae15581c3c