### PR TITLE
Refactor document title handling

### DIFF
--- a/src/DeveloperMetricsPage.tsx
+++ b/src/DeveloperMetricsPage.tsx
@@ -5,12 +5,25 @@ import { useAuth } from './AuthContext';
 import { searchUsers } from './services/github';
 import { useDeveloperMetrics } from './hooks/useDeveloperMetrics';
 import { useDebounce } from './hooks/useDebounce';
+import { useDocumentTitle } from './hooks/useDocumentTitle';
 import { GitHubUser } from './services/auth';
 import LoadingOverlay from './LoadingOverlay';
 import SearchUserBox from './SearchUserBox';
 import DeveloperMetricCard from './DeveloperMetricCard';
 
-const METRIC_INFO = [
+import type { DeveloperMetrics } from './services/github';
+
+interface MetricInfo {
+  name: string;
+  key: keyof DeveloperMetrics;
+  valueKey: keyof DeveloperMetrics;
+  valueDesc: string;
+  brief: string;
+  details: string;
+  format?: (n: number) => string;
+}
+
+const METRIC_INFO: MetricInfo[] = [
   {
     name: 'Merge Success',
     key: 'mergeSuccess',
@@ -87,13 +100,7 @@ export default function DeveloperMetricsPage() {
     'Building radar charts...',
   ];
 
-  useEffect(() => {
-    const prev = document.title;
-    document.title = 'Developer insights';
-    return () => {
-      document.title = prev;
-    };
-  }, []);
+  useDocumentTitle('Developer insights');
 
   useEffect(() => {
     if (!debouncedQuery) {
@@ -241,10 +248,8 @@ export default function DeveloperMetricsPage() {
                   brief={info.brief}
                   details={info.details}
                   valueDesc={info.valueDesc}
-                  score={
-                    data ? (data as any)[info.key as keyof typeof data] : null
-                  }
-                  value={data ? (data as any)[info.valueKey] : 0}
+                  score={data ? (data[info.key] as number) : null}
+                  value={data ? (data[info.valueKey] as number) : 0}
                   format={info.format}
                 />
               ))}

--- a/src/PullRequest.tsx
+++ b/src/PullRequest.tsx
@@ -4,6 +4,7 @@ import { Timeline, Heading, TabNav } from '@primer/react';
 import { Box, Spinner, Button, Text } from '@primer/react';
 import { useParams, useLocation, Link as RouterLink } from 'react-router-dom';
 import { useAuth } from './AuthContext';
+import { useDocumentTitle } from './hooks/useDocumentTitle';
 
 interface TimelineEntry {
   label: string;
@@ -17,15 +18,7 @@ export default function PullRequestPage() {
   const [title, setTitle] = useState<string>(location.state?.title || '');
   const [loading, setLoading] = useState<boolean>(true);
 
-  useEffect(() => {
-    if (title) {
-      const prev = document.title;
-      document.title = title;
-      return () => {
-        document.title = prev;
-      };
-    }
-  }, [title]);
+  useDocumentTitle(title);
 
   useEffect(() => {
     async function fetchData() {

--- a/src/RepoInsightsPage.tsx
+++ b/src/RepoInsightsPage.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Box, TextInput, Button, Heading, Text, Label } from '@primer/react';
 import { useAuth } from './AuthContext';
 import { useRepoInsights } from './hooks/useRepoInsights';
 import LoadingOverlay from './LoadingOverlay';
+import { useDocumentTitle } from './hooks/useDocumentTitle';
 
 export default function RepoInsightsPage() {
   const { token } = useAuth();
@@ -16,13 +17,7 @@ export default function RepoInsightsPage() {
     'Analyzing pull requests...',
   ];
 
-  useEffect(() => {
-    const prev = document.title;
-    document.title = 'Repo insights';
-    return () => {
-      document.title = prev;
-    };
-  }, []);
+  useDocumentTitle('Repo insights');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/hooks/useDocumentTitle.ts
+++ b/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+export function useDocumentTitle(title?: string | null) {
+  useEffect(() => {
+    if (!title) return;
+    const prev = document.title;
+    document.title = title;
+    return () => {
+      document.title = prev;
+    };
+  }, [title]);
+}


### PR DESCRIPTION
## Summary
- create `useDocumentTitle` hook for consistent title updates
- type `DeveloperMetricsPage` metrics metadata
- use the new hook across pages

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851adcba34c832c97a28e79a782cb2f