### PR TITLE
Add theme switcher

### DIFF
--- a/src/ColorModeToggle.tsx
+++ b/src/ColorModeToggle.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Button } from '@primer/react';
 import { MoonIcon, SunIcon } from '@primer/octicons-react';
 import { useThemeMode } from './ThemeModeContext';
 
@@ -7,14 +6,16 @@ export default function ColorModeToggle() {
   const { colorMode, toggleColorMode } = useThemeMode();
   const isDay = colorMode === 'day';
   return (
-    <Button
-      size="small"
+    <button
+      role="switch"
+      aria-checked={!isDay}
       onClick={toggleColorMode}
       aria-label={`Switch to ${isDay ? 'dark' : 'light'} mode`}
-      leadingIcon={isDay ? MoonIcon : SunIcon}
-      sx={{ width: 80 }}
+      className={`color-mode-switch${isDay ? '' : ' night'}`}
     >
-      {isDay ? 'Dark' : 'Light'}
-    </Button>
+      <SunIcon />
+      <MoonIcon />
+      <span className="color-mode-switch-thumb" />
+    </button>
   );
 }

--- a/src/ColorModeToggle.tsx
+++ b/src/ColorModeToggle.tsx
@@ -5,18 +5,27 @@ import { useThemeMode } from './ThemeModeContext';
 export default function ColorModeToggle() {
   const { colorMode, toggleColorMode } = useThemeMode();
   const isDay = colorMode === 'day';
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggleColorMode();
+    }
+  };
+
   return (
-    <button
-      type="button"
+    <div
       role="switch"
+      tabIndex={0}
       aria-checked={!isDay}
       onClick={toggleColorMode}
+      onKeyDown={handleKeyDown}
       aria-label={`Switch to ${isDay ? 'dark' : 'light'} mode`}
       className={`color-mode-switch${isDay ? '' : ' night'}`}
     >
       <SunIcon className={`color-mode-icon${isDay ? ' active' : ''}`} />
       <MoonIcon className={`color-mode-icon${!isDay ? ' active' : ''}`} />
       <span className="color-mode-switch-thumb" />
-    </button>
+    </div>
   );
 }

--- a/src/ColorModeToggle.tsx
+++ b/src/ColorModeToggle.tsx
@@ -23,9 +23,13 @@ export default function ColorModeToggle() {
       aria-label={`Switch to ${isDay ? 'dark' : 'light'} mode`}
       className={`color-mode-switch${isDay ? '' : ' night'}`}
     >
-      <SunIcon className={`color-mode-icon${isDay ? ' active' : ''}`} />
-      <MoonIcon className={`color-mode-icon${!isDay ? ' active' : ''}`} />
-      <span className="color-mode-switch-thumb" />
+      <span className="color-mode-switch-thumb">
+        {isDay ? (
+          <SunIcon className="color-mode-icon" />
+        ) : (
+          <MoonIcon className="color-mode-icon" />
+        )}
+      </span>
     </div>
   );
 }

--- a/src/ColorModeToggle.tsx
+++ b/src/ColorModeToggle.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Button } from '@primer/react';
+import { MoonIcon, SunIcon } from '@primer/octicons-react';
+import { useThemeMode } from './ThemeModeContext';
+
+export default function ColorModeToggle() {
+  const { colorMode, toggleColorMode } = useThemeMode();
+  const isDay = colorMode === 'day';
+  return (
+    <Button
+      size="small"
+      onClick={toggleColorMode}
+      aria-label={`Switch to ${isDay ? 'dark' : 'light'} mode`}
+      leadingIcon={isDay ? MoonIcon : SunIcon}
+      sx={{ width: 80 }}
+    >
+      {isDay ? 'Dark' : 'Light'}
+    </Button>
+  );
+}

--- a/src/ColorModeToggle.tsx
+++ b/src/ColorModeToggle.tsx
@@ -7,14 +7,15 @@ export default function ColorModeToggle() {
   const isDay = colorMode === 'day';
   return (
     <button
+      type="button"
       role="switch"
       aria-checked={!isDay}
       onClick={toggleColorMode}
       aria-label={`Switch to ${isDay ? 'dark' : 'light'} mode`}
       className={`color-mode-switch${isDay ? '' : ' night'}`}
     >
-      <SunIcon />
-      <MoonIcon />
+      <SunIcon className={`color-mode-icon${isDay ? ' active' : ''}`} />
+      <MoonIcon className={`color-mode-icon${!isDay ? ' active' : ''}`} />
       <span className="color-mode-switch-thumb" />
     </button>
   );

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -4,6 +4,7 @@ import { Octokit } from '@octokit/rest';
 import { TriangleUpIcon, SignOutIcon } from '@primer/octicons-react';
 import { Link as RouterLink } from 'react-router-dom';
 import { useAuth } from './AuthContext';
+import ColorModeToggle from './ColorModeToggle';
 
 interface GitHubUser {
   login: string;
@@ -66,6 +67,7 @@ export default function Header({ breadcrumb }: HeaderProps) {
       </Box>
       {user && (
         <Box display="flex" alignItems="center" sx={{ gap: 2 }}>
+          <ColorModeToggle />
           <Avatar src={user.avatar_url} size={24} />
           <Text fontSize={1} sx={{ fontFamily: 'mono' }}>
             {user.login}

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -10,6 +10,7 @@ import {
 import { TriangleUpIcon } from '@primer/octicons-react';
 import GlowingCard from './GlowingCard';
 import MagicButton from './MagicButton';
+import ColorModeToggle from './ColorModeToggle';
 
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from './AuthContext';
@@ -41,6 +42,9 @@ export default function Login() {
       alignItems="center"
       minHeight="100vh"
     >
+      <Box position="absolute" top={3} right={3}>
+        <ColorModeToggle />
+      </Box>
       <GlowingCard>
         <Box as="form" onSubmit={handleSubmit}>
           <Heading

--- a/src/ThemeModeContext.tsx
+++ b/src/ThemeModeContext.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { ThemeProvider } from '@primer/react';
+
+export type ColorMode = 'day' | 'night';
+
+interface ThemeModeContextValue {
+  colorMode: ColorMode;
+  toggleColorMode: () => void;
+}
+
+const ThemeModeContext = createContext<ThemeModeContextValue | undefined>(
+  undefined
+);
+
+export const ThemeModeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [colorMode, setColorMode] = useState<ColorMode>(() => {
+    const stored = localStorage.getItem('colorMode');
+    return stored === 'night' ? 'night' : 'day';
+  });
+
+  useEffect(() => {
+    localStorage.setItem('colorMode', colorMode);
+  }, [colorMode]);
+
+  const toggleColorMode = () => {
+    setColorMode((m) => (m === 'day' ? 'night' : 'day'));
+  };
+
+  return (
+    <ThemeModeContext.Provider value={{ colorMode, toggleColorMode }}>
+      <ThemeProvider colorMode={colorMode}>{children}</ThemeProvider>
+    </ThemeModeContext.Provider>
+  );
+};
+
+export function useThemeMode() {
+  const ctx = useContext(ThemeModeContext);
+  if (!ctx)
+    throw new Error('useThemeMode must be used within ThemeModeProvider');
+  return ctx;
+}

--- a/src/ThemeModeContext.tsx
+++ b/src/ThemeModeContext.tsx
@@ -15,13 +15,21 @@ const ThemeModeContext = createContext<ThemeModeContextValue | undefined>(
 export const ThemeModeProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
+  const STORAGE_KEY = 'colorMode';
+
   const [colorMode, setColorMode] = useState<ColorMode>(() => {
-    const stored = localStorage.getItem('colorMode');
-    return stored === 'night' ? 'night' : 'day';
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'day' || stored === 'night') {
+      return stored;
+    }
+    const prefersDark =
+      typeof window !== 'undefined' &&
+      window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+    return prefersDark ? 'night' : 'day';
   });
 
   useEffect(() => {
-    localStorage.setItem('colorMode', colorMode);
+    localStorage.setItem(STORAGE_KEY, colorMode);
   }, [colorMode]);
 
   const toggleColorMode = () => {

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import App from '../App';
 import { AuthProvider, useAuth } from '../AuthContext';
+import { ThemeModeProvider } from '../ThemeModeContext';
 import * as metricsHook from '../hooks/usePullRequestMetrics';
 
 jest.mock('../hooks/usePullRequestMetrics');
@@ -19,11 +20,13 @@ beforeEach(() => {
 
 test('shows login when not authenticated', () => {
   render(
-    <AuthProvider>
-      <MemoryRouter>
-        <App />
-      </MemoryRouter>
-    </AuthProvider>
+    <ThemeModeProvider>
+      <AuthProvider>
+        <MemoryRouter>
+          <App />
+        </MemoryRouter>
+      </AuthProvider>
+    </ThemeModeProvider>
   );
   expect(screen.getByText(/PR-ism/i)).toBeInTheDocument();
 });
@@ -42,9 +45,11 @@ function LoggedIn() {
 
 test('shows home card when authenticated', async () => {
   render(
-    <AuthProvider>
-      <LoggedIn />
-    </AuthProvider>
+    <ThemeModeProvider>
+      <AuthProvider>
+        <LoggedIn />
+      </AuthProvider>
+    </ThemeModeProvider>
   );
   expect(screen.getByText('Pull request insights')).toBeInTheDocument();
   expect(screen.getByText('Developer insights')).toBeInTheDocument();
@@ -66,9 +71,11 @@ test('shows breadcrumb on insights page', async () => {
   }
 
   render(
-    <AuthProvider>
-      <Wrapper />
-    </AuthProvider>
+    <ThemeModeProvider>
+      <AuthProvider>
+        <Wrapper />
+      </AuthProvider>
+    </ThemeModeProvider>
   );
   expect(screen.getByText('Pull request insights')).toBeInTheDocument();
 });

--- a/src/__tests__/DeveloperMetricsPage.test.tsx
+++ b/src/__tests__/DeveloperMetricsPage.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import DeveloperMetricsPage from '../DeveloperMetricsPage';
 import { AuthProvider, useAuth } from '../AuthContext';
+import { ThemeModeProvider } from '../ThemeModeContext';
 import * as metricsHook from '../hooks/useDeveloperMetrics';
 import * as github from '../services/github';
 
@@ -28,9 +29,11 @@ test('renders page heading', () => {
     loading: false,
   });
   render(
-    <AuthProvider>
-      <Wrapper />
-    </AuthProvider>
+    <ThemeModeProvider>
+      <AuthProvider>
+        <Wrapper />
+      </AuthProvider>
+    </ThemeModeProvider>
   );
   expect(
     screen.getByRole('heading', { name: /developer insights/i })
@@ -46,9 +49,11 @@ test('displays suggestions and handles selection', async () => {
     { login: 'octo', avatar_url: 'x' },
   ]);
   render(
-    <AuthProvider>
-      <Wrapper />
-    </AuthProvider>
+    <ThemeModeProvider>
+      <AuthProvider>
+        <Wrapper />
+      </AuthProvider>
+    </ThemeModeProvider>
   );
   const user = userEvent.setup();
   await user.type(screen.getByPlaceholderText(/search github user/i), 'oct');
@@ -66,9 +71,11 @@ test('logs error on search failure', async () => {
   (github.searchUsers as jest.Mock).mockRejectedValue(new Error('fail'));
   const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
   render(
-    <AuthProvider>
-      <Wrapper />
-    </AuthProvider>
+    <ThemeModeProvider>
+      <AuthProvider>
+        <Wrapper />
+      </AuthProvider>
+    </ThemeModeProvider>
   );
   const user = userEvent.setup();
   await user.type(screen.getByPlaceholderText(/search github user/i), 'oct');

--- a/src/__tests__/Header.test.tsx
+++ b/src/__tests__/Header.test.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import Header from '../Header';
 import { AuthProvider, useAuth } from '../AuthContext';
+import { ThemeModeProvider } from '../ThemeModeContext';
 import { MemoryRouter } from 'react-router-dom';
 import { Octokit } from '@octokit/rest';
 
@@ -31,9 +32,11 @@ test('fetches and displays user info', async () => {
   }
 
   render(
-    <AuthProvider>
-      <Wrapper />
-    </AuthProvider>
+    <ThemeModeProvider>
+      <AuthProvider>
+        <Wrapper />
+      </AuthProvider>
+    </ThemeModeProvider>
   );
 
   await waitFor(() => expect(screen.getByText('octo')).toBeInTheDocument());

--- a/src/__tests__/Login.test.tsx
+++ b/src/__tests__/Login.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Login from '../Login';
 import { AuthProvider, useAuth } from '../AuthContext';
+import { ThemeModeProvider } from '../ThemeModeContext';
 import { MemoryRouter } from 'react-router-dom';
 import * as authService from '../services/auth';
 
@@ -20,11 +21,13 @@ test('login submits provided token', async () => {
     return <Login />;
   }
   render(
-    <AuthProvider>
-      <MemoryRouter>
-        <Wrapper />
-      </MemoryRouter>
-    </AuthProvider>
+    <ThemeModeProvider>
+      <AuthProvider>
+        <MemoryRouter>
+          <Wrapper />
+        </MemoryRouter>
+      </AuthProvider>
+    </ThemeModeProvider>
   );
   const input = screen.getByPlaceholderText(/github token/i);
   const user = userEvent.setup();
@@ -37,11 +40,13 @@ test('shows error when token is invalid', async () => {
   (authService.validateToken as jest.Mock).mockRejectedValue(new Error('bad'));
 
   render(
-    <AuthProvider>
-      <MemoryRouter>
-        <Login />
-      </MemoryRouter>
-    </AuthProvider>
+    <ThemeModeProvider>
+      <AuthProvider>
+        <MemoryRouter>
+          <Login />
+        </MemoryRouter>
+      </AuthProvider>
+    </ThemeModeProvider>
   );
   const user = userEvent.setup();
   await user.type(screen.getByPlaceholderText(/github token/i), 'bad');

--- a/src/__tests__/ThemeModeContext.test.tsx
+++ b/src/__tests__/ThemeModeContext.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { ThemeModeProvider, useThemeMode } from '../ThemeModeContext';
+
+test('toggles color mode', () => {
+  const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <ThemeModeProvider>{children}</ThemeModeProvider>
+  );
+  const { result } = renderHook(() => useThemeMode(), { wrapper });
+
+  expect(result.current.colorMode).toBe('day');
+  act(() => result.current.toggleColorMode());
+  expect(result.current.colorMode).toBe('night');
+});

--- a/src/__tests__/ThemeModeContext.test.tsx
+++ b/src/__tests__/ThemeModeContext.test.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import { renderHook, act } from '@testing-library/react';
 import { ThemeModeProvider, useThemeMode } from '../ThemeModeContext';
 
+afterEach(() => {
+  localStorage.clear();
+});
+
 test('toggles color mode', () => {
   const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     <ThemeModeProvider>{children}</ThemeModeProvider>
@@ -10,5 +14,14 @@ test('toggles color mode', () => {
 
   expect(result.current.colorMode).toBe('day');
   act(() => result.current.toggleColorMode());
+  expect(result.current.colorMode).toBe('night');
+});
+
+test('reads initial mode from localStorage', () => {
+  localStorage.setItem('colorMode', 'night');
+  const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <ThemeModeProvider>{children}</ThemeModeProvider>
+  );
+  const { result } = renderHook(() => useThemeMode(), { wrapper });
   expect(result.current.colorMode).toBe('night');
 });

--- a/src/index.css
+++ b/src/index.css
@@ -116,16 +116,25 @@ body {
   align-items: center;
   justify-content: space-between;
   padding: 0 4px;
-  background: var(--color-neutral-muted);
+  background: var(--bgColor-neutral-muted);
   border-radius: 12px;
   border: none;
   cursor: pointer;
 }
 
+.color-mode-switch.night {
+  background: var(--bgColor-neutral-emphasis);
+}
+
 .color-mode-switch svg {
   width: 14px;
   height: 14px;
-  color: var(--color-fg-default);
+  color: var(--fgColor-muted);
+  transition: color 0.2s;
+}
+
+.color-mode-switch svg.active {
+  color: var(--fgColor-accent);
 }
 
 .color-mode-switch-thumb {
@@ -135,7 +144,8 @@ body {
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  background: var(--color-canvas-default);
+  background: var(--bgColor-default);
+  box-shadow: 0 0 0 2px var(--fgColor-accent) inset;
   transition: transform 0.2s;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -36,7 +36,7 @@ body {
 /* Glowing card effect */
 .glow-card {
   position: relative;
-  background: var(--color-canvas-default, #0d1117);
+  background: var(--color-canvas-default);
   border-radius: var(--magic-radius);
   overflow: visible;
   z-index: 0;
@@ -105,4 +105,40 @@ body {
 .magic-button:focus-visible {
   outline: 2px solid #fff;
   outline-offset: 2px;
+}
+
+/* Color mode switch */
+.color-mode-switch {
+  position: relative;
+  width: 48px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 4px;
+  background: var(--color-neutral-muted);
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+}
+
+.color-mode-switch svg {
+  width: 14px;
+  height: 14px;
+  color: var(--color-fg-default);
+}
+
+.color-mode-switch-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-canvas-default);
+  transition: transform 0.2s;
+}
+
+.color-mode-switch.night .color-mode-switch-thumb {
+  transform: translateX(24px);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -112,9 +112,6 @@ body {
   position: relative;
   width: 48px;
   height: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   padding: 0 4px;
   background: var(--bgColor-neutral-muted);
   border-radius: 12px;
@@ -126,18 +123,7 @@ body {
   background: var(--bgColor-neutral-emphasis);
 }
 
-.color-mode-switch svg {
-  width: 14px;
-  height: 14px;
-  color: var(--fgColor-muted);
-  fill: currentColor;
-  transition: color 0.2s;
-}
 
-.color-mode-switch svg.active {
-  color: var(--fgColor-accent);
-  fill: currentColor;
-}
 
 .color-mode-switch-thumb {
   position: absolute;
@@ -149,6 +135,16 @@ body {
   background: var(--bgColor-default);
   box-shadow: 0 0 0 2px var(--fgColor-accent) inset;
   transition: transform 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.color-mode-switch-thumb svg {
+  width: 14px;
+  height: 14px;
+  color: var(--fgColor-accent);
+  fill: currentColor;
 }
 
 .color-mode-switch:focus-visible {

--- a/src/index.css
+++ b/src/index.css
@@ -118,8 +118,8 @@ body {
   padding: 0 4px;
   background: var(--bgColor-neutral-muted);
   border-radius: 12px;
-  border: none;
   cursor: pointer;
+  outline: none;
 }
 
 .color-mode-switch.night {
@@ -130,11 +130,13 @@ body {
   width: 14px;
   height: 14px;
   color: var(--fgColor-muted);
+  fill: currentColor;
   transition: color 0.2s;
 }
 
 .color-mode-switch svg.active {
   color: var(--fgColor-accent);
+  fill: currentColor;
 }
 
 .color-mode-switch-thumb {
@@ -147,6 +149,11 @@ body {
   background: var(--bgColor-default);
   box-shadow: 0 0 0 2px var(--fgColor-accent) inset;
   transition: transform 0.2s;
+}
+
+.color-mode-switch:focus-visible {
+  outline: 2px solid var(--fgColor-accent);
+  outline-offset: 2px;
 }
 
 .color-mode-switch.night .color-mode-switch-thumb {

--- a/src/index.css
+++ b/src/index.css
@@ -114,6 +114,7 @@ body {
   height: 24px;
   padding: 0 4px;
   background: var(--bgColor-neutral-muted);
+  box-shadow: 0 0 0 1px var(--borderColor-default) inset;
   border-radius: 12px;
   cursor: pointer;
   outline: none;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { ThemeProvider, BaseStyles } from '@primer/react';
+import { BaseStyles } from '@primer/react';
+import { ThemeModeProvider } from './ThemeModeContext';
 import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App';
@@ -9,13 +10,13 @@ import { AuthProvider } from './AuthContext';
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <ThemeProvider colorMode="auto">
+      <ThemeModeProvider>
         <BaseStyles>
           <AuthProvider>
             <App />
           </AuthProvider>
         </BaseStyles>
-      </ThemeProvider>
+      </ThemeModeProvider>
     </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add theme context with toggle component
- allow users to switch between light and dark mode from header and login screen
- adjust tests for new theme provider

## Testing
- `npm run lint`
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853153fe5fc832c90c7be142c151c17