### PR TITLE
Fix breadcrumb trailing slash on home

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -181,3 +181,8 @@ body {
   font-weight: 600;
   font-size: 1rem;
 }
+
+/* Hide divider when only a single breadcrumb item exists */
+.breadcrumbs-modern ol > li:first-child:last-child::after {
+  content: none;
+}


### PR DESCRIPTION
## Summary
- ensure the breadcrumb doesn't show a trailing slash on the home page by hiding the divider when only one item is present

## Testing
- `npm run lint`
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857a6333ee4832c8b9ac2cf2e90b797