### PR TITLE
Improve SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,22 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="PR-ism visualizes GitHub pull request metrics and insights."
+    />
+    <meta name="keywords" content="GitHub,pull request,metrics,analytics" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://example.com/" />
+    <meta property="og:title" content="PR-ism" />
+    <meta
+      property="og:description"
+      content="Simple React app that shows pull request metrics using the GitHub API."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://example.com/" />
     <title>PR-ism</title>
   </head>
   <body>

--- a/src/DeveloperMetricsPage.tsx
+++ b/src/DeveloperMetricsPage.tsx
@@ -6,6 +6,7 @@ import { searchUsers } from './services/github';
 import { useDeveloperMetrics } from './hooks/useDeveloperMetrics';
 import { useDebounce } from './hooks/useDebounce';
 import { useDocumentTitle } from './hooks/useDocumentTitle';
+import { useMetaDescription } from './hooks/useMetaDescription';
 import { GitHubUser } from './services/auth';
 import LoadingOverlay from './LoadingOverlay';
 import SearchUserBox from './SearchUserBox';
@@ -103,6 +104,7 @@ export default function DeveloperMetricsPage() {
   ];
 
   useDocumentTitle('Developer insights');
+  useMetaDescription('Developer insights for GitHub pull requests.');
 
   useEffect(() => {
     if (!debouncedQuery) {

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Box, Text } from '@primer/react';
+import { useDocumentTitle } from './hooks/useDocumentTitle';
+import { useMetaDescription } from './hooks/useMetaDescription';
 import {
   RepoIcon,
   PeopleIcon,
@@ -8,6 +10,8 @@ import {
 import { Link as RouterLink } from 'react-router-dom';
 
 export default function Home() {
+  useDocumentTitle('PR-ism Home');
+  useMetaDescription('Access GitHub pull request insights and metrics.');
   return (
     <Box display="flex" justifyContent="center" mt={6} sx={{ gap: 3 }}>
       <Box

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -15,12 +15,18 @@ import ColorModeToggle from './ColorModeToggle';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from './AuthContext';
 import { validateToken } from './services/auth';
+import { useDocumentTitle } from './hooks/useDocumentTitle';
+import { useMetaDescription } from './hooks/useMetaDescription';
 
 export default function Login() {
   const { login } = useAuth();
   const navigate = useNavigate();
   const [value, setValue] = useState('');
   const [error, setError] = useState<string | null>(null);
+  useDocumentTitle('Sign in to PR-ism');
+  useMetaDescription(
+    'Login with your GitHub token to access pull request metrics.'
+  );
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/MetricsPage.tsx
+++ b/src/MetricsPage.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import MetricsTable from './MetricsTable';
+import { useDocumentTitle } from './hooks/useDocumentTitle';
+import { useMetaDescription } from './hooks/useMetaDescription';
 
 export default function MetricsPage() {
+  useDocumentTitle('Pull request insights');
+  useMetaDescription('Metrics and analytics for your pull requests.');
   return <MetricsTable />;
 }

--- a/src/PullRequest.tsx
+++ b/src/PullRequest.tsx
@@ -5,6 +5,7 @@ import { Box, Spinner, Button, Text } from '@primer/react';
 import { useParams, useLocation, Link as RouterLink } from 'react-router-dom';
 import { useAuth } from './AuthContext';
 import { useDocumentTitle } from './hooks/useDocumentTitle';
+import { useMetaDescription } from './hooks/useMetaDescription';
 
 interface TimelineEntry {
   label: string;
@@ -19,6 +20,7 @@ export default function PullRequestPage() {
   const [loading, setLoading] = useState<boolean>(true);
 
   useDocumentTitle(title);
+  useMetaDescription(title ? `Details for PR ${title}` : null);
 
   useEffect(() => {
     async function fetchData() {

--- a/src/RepoInsightsPage.tsx
+++ b/src/RepoInsightsPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from './AuthContext';
 import { useRepoInsights } from './hooks/useRepoInsights';
 import LoadingOverlay from './LoadingOverlay';
 import { useDocumentTitle } from './hooks/useDocumentTitle';
+import { useMetaDescription } from './hooks/useMetaDescription';
 
 export default function RepoInsightsPage() {
   const { token } = useAuth();
@@ -18,6 +19,7 @@ export default function RepoInsightsPage() {
   ];
 
   useDocumentTitle('Repository insights');
+  useMetaDescription('Repository metrics and DevOps insights.');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/hooks/useMetaDescription.ts
+++ b/src/hooks/useMetaDescription.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+
+export function useMetaDescription(description?: string | null) {
+  useEffect(() => {
+    if (!description) return;
+    const element = document.querySelector('meta[name="description"]');
+    if (!element) return;
+    const prev = element.getAttribute('content');
+    element.setAttribute('content', description);
+    return () => {
+      if (prev) {
+        element.setAttribute('content', prev);
+      }
+    };
+  }, [description]);
+}


### PR DESCRIPTION
## Summary
- add essential SEO meta tags in `index.html`
- create `useMetaDescription` React hook
- set page titles and descriptions across the app

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857a7722ec8832cb3800f1f6c0df88b