### PR TITLE
Switch to heroUI provider

### DIFF
--- a/src/ThemeModeContext.tsx
+++ b/src/ThemeModeContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { ThemeProvider } from '@primer/react';
+import { HeroUIProvider } from '@heroui/system';
 
 export type ColorMode = 'day' | 'night';
 
@@ -30,6 +30,9 @@ export const ThemeModeProvider: React.FC<{ children: React.ReactNode }> = ({
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, colorMode);
+    if (typeof document !== 'undefined') {
+      document.documentElement.classList.toggle('dark', colorMode === 'night');
+    }
   }, [colorMode]);
 
   const toggleColorMode = () => {
@@ -38,7 +41,7 @@ export const ThemeModeProvider: React.FC<{ children: React.ReactNode }> = ({
 
   return (
     <ThemeModeContext.Provider value={{ colorMode, toggleColorMode }}>
-      <ThemeProvider colorMode={colorMode}>{children}</ThemeProvider>
+      <HeroUIProvider>{children}</HeroUIProvider>
     </ThemeModeContext.Provider>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,14 @@
 body {
   margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+}
+
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
 }
 
 #root {


### PR DESCRIPTION
## Summary
- replace Primer ThemeProvider with heroUI HeroUIProvider
- toggle `dark` class on document root when color mode changes
- fix HeroUI import path

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857b3caee58832cbe90d796d4c225bc