### PR TITLE
Switch Primer UI to heroUI

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,8 @@ module.exports = {
     '\\.(css|less|scss)$': 'identity-obj-proxy',
     '^@primer/react$': '<rootDir>/src/primer-shim.tsx',
     '^@primer/react/drafts$': '<rootDir>/src/primer-drafts-shim.tsx',
-    '^@primer/octicons-react$': '<rootDir>/src/octicons-shim.tsx'
+    '^@primer/octicons-react$': '<rootDir>/src/octicons-shim.tsx',
+    '^@heroui/react$': '<rootDir>/src/heroui-shim.tsx'
   },
   coverageThreshold: {
     global: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box } from '@primer/react';
+import { Box } from '@heroui/react';
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import Login from './Login';
 import MetricsPage from './MetricsPage';

--- a/src/DeveloperMetricCard.tsx
+++ b/src/DeveloperMetricCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Heading, Text, Label } from '@primer/react';
+import { Box, Heading, Text, Badge } from '@heroui/react';
 
 interface Props {
   name: string;
@@ -48,9 +48,9 @@ export default function DeveloperMetricCard({
       >
         {name}
         {typeof score === 'number' && (
-          <Label variant={variant} size="small">
+          <Badge variant={variant} size="small">
             {score}
-          </Label>
+          </Badge>
         )}
       </Heading>
       <Text sx={{ fontSize: 1 }}>{brief}</Text>
@@ -58,9 +58,9 @@ export default function DeveloperMetricCard({
         {details}
       </Text>
       <Text as="p" sx={{ mt: 1, fontSize: 0 }}>
-        <Label variant={variant} size="small" mr={1}>
+        <Badge variant={variant} size="small" mr={1}>
           {format ? format(value) : value}
-        </Label>{' '}
+        </Badge>{' '}
         {valueDesc}
       </Text>
     </Box>

--- a/src/DeveloperMetricsPage.tsx
+++ b/src/DeveloperMetricsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Avatar, Heading, Text, Link } from '@primer/react';
+import { Box, Avatar, Heading, Text, Link } from '@heroui/react';
 import { RadarChart, Radar, PolarAngleAxis } from 'recharts';
 import { useAuth } from './AuthContext';
 import { searchUsers } from './services/github';

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Avatar, Text, Button, Breadcrumbs } from '@primer/react';
+import { Box, Avatar, Text, Button, Breadcrumbs } from '@heroui/react';
 import { Octokit } from '@octokit/rest';
 import { TriangleUpIcon, SignOutIcon } from '@primer/octicons-react';
 import { Link as RouterLink } from 'react-router-dom';

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Text } from '@primer/react';
+import { Box, Text } from '@heroui/react';
 import { useDocumentTitle } from './hooks/useDocumentTitle';
 import { useMetaDescription } from './hooks/useMetaDescription';
 import {

--- a/src/LoadingOverlay.tsx
+++ b/src/LoadingOverlay.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Spinner, Text } from '@primer/react';
+import { Box, Spinner, Text } from '@heroui/react';
 
 interface LoadingOverlayProps {
   show: boolean;

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,12 +1,5 @@
 import React, { useState } from 'react';
-import {
-  Box,
-  TextInput,
-  Heading,
-  Text,
-  FormControl,
-  Link,
-} from '@primer/react';
+import { Box, Input, Heading, Text, FormControl, Link } from '@heroui/react';
 import { TriangleUpIcon } from '@primer/octicons-react';
 import GlowingCard from './GlowingCard';
 import MagicButton from './MagicButton';
@@ -67,7 +60,7 @@ export default function Login() {
             <FormControl.Label htmlFor="token-input">
               Personal access token
             </FormControl.Label>
-            <TextInput
+            <Input
               id="token-input"
               type="password"
               value={value}

--- a/src/MetricsTable.tsx
+++ b/src/MetricsTable.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 // Use the experimental DataTable component from Primer React
-import { DataTable, Table, createColumnHelper } from '@primer/react/drafts';
+import { DataTable, Table, createColumnHelper } from '@heroui/react';
 import {
   Box,
   FormControl,
@@ -10,7 +10,7 @@ import {
   Button,
   StateLabel,
   Tooltip,
-} from '@primer/react';
+} from '@heroui/react';
 import { useNavigate } from 'react-router-dom';
 import { usePullRequestMetrics } from './hooks/usePullRequestMetrics';
 import { PRItem } from './types';

--- a/src/PullRequest.tsx
+++ b/src/PullRequest.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Octokit } from '@octokit/rest';
-import { Timeline, Heading, TabNav } from '@primer/react';
-import { Box, Spinner, Button, Text } from '@primer/react';
+import { Timeline, Heading, TabNav } from '@heroui/react';
+import { Box, Spinner, Button, Text } from '@heroui/react';
 import { useParams, useLocation, Link as RouterLink } from 'react-router-dom';
 import { useAuth } from './AuthContext';
 import { useDocumentTitle } from './hooks/useDocumentTitle';

--- a/src/RepoInsightsPage.tsx
+++ b/src/RepoInsightsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, TextInput, Button, Heading, Text, Label } from '@primer/react';
+import { Box, Input, Button, Heading, Text, Badge } from '@heroui/react';
 import { useAuth } from './AuthContext';
 import { useRepoInsights } from './hooks/useRepoInsights';
 import LoadingOverlay from './LoadingOverlay';
@@ -39,7 +39,7 @@ export default function RepoInsightsPage() {
     <Box p={3} position="relative">
       <form onSubmit={handleSubmit}>
         <Box mb={3} display="flex" sx={{ gap: 2 }}>
-          <TextInput
+          <Input
             placeholder="owner/repo or URL"
             value={input}
             onChange={(e) => setInput(e.target.value)}
@@ -123,9 +123,9 @@ function MetricCard({ title, value }: MetricCardProps) {
       <Heading as="h3" sx={{ fontSize: 2, mb: 2 }}>
         {title}
       </Heading>
-      <Label variant="accent" sx={{ fontSize: 1 }}>
+      <Badge variant="accent" sx={{ fontSize: 1 }}>
         {value}
-      </Label>
+      </Badge>
     </Box>
   );
 }

--- a/src/SearchUserBox.tsx
+++ b/src/SearchUserBox.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, TextInput, Avatar, Text } from '@primer/react';
+import { Box, Input, Avatar, Text } from '@heroui/react';
 import { GitHubUser } from './services/auth';
 
 interface Props {
@@ -17,7 +17,7 @@ export default function SearchUserBox({
 }: Props) {
   return (
     <Box position="relative" width="100%" maxWidth={300}>
-      <TextInput
+      <Input
         placeholder="Search GitHub users"
         value={query}
         onChange={(e) => onQueryChange(e.target.value)}

--- a/src/__tests__/MetricsTable.test.tsx
+++ b/src/__tests__/MetricsTable.test.tsx
@@ -6,10 +6,20 @@ import { AuthProvider } from '../AuthContext';
 import * as metricsHook from '../hooks/usePullRequestMetrics';
 import { PRItem } from '../types';
 
-jest.mock('@primer/react/drafts', () => ({
-  DataTable: (props: any) => <table>{props.children}</table>,
+jest.mock('@heroui/react', () => ({
+  DataTable: () => <table />,
   Table: { Pagination: () => null },
   createColumnHelper: () => ({ column: (c: any) => c }),
+  FormControl: Object.assign(({ children }: any) => <div>{children}</div>, {
+    Label: ({ children }: any) => <label>{children}</label>,
+  }),
+  Select: ({ children, ...props }: any) => <select {...props}>{children}</select>,
+  Box: ({ children }: any) => <div>{children}</div>,
+  Button: ({ children }: any) => <button>{children}</button>,
+  Text: ({ children }: any) => <span>{children}</span>,
+  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+  StateLabel: ({ children }: any) => <span>{children}</span>,
+  Tooltip: ({ children }: any) => <span>{children}</span>,
 }));
 
 const sample: PRItem[] = [

--- a/src/__tests__/MetricsTable.test.tsx
+++ b/src/__tests__/MetricsTable.test.tsx
@@ -6,22 +6,6 @@ import { AuthProvider } from '../AuthContext';
 import * as metricsHook from '../hooks/usePullRequestMetrics';
 import { PRItem } from '../types';
 
-jest.mock('@heroui/react', () => ({
-  DataTable: () => <table />,
-  Table: { Pagination: () => null },
-  createColumnHelper: () => ({ column: (c: any) => c }),
-  FormControl: Object.assign(({ children }: any) => <div>{children}</div>, {
-    Label: ({ children }: any) => <label>{children}</label>,
-  }),
-  Select: ({ children, ...props }: any) => <select {...props}>{children}</select>,
-  Box: ({ children }: any) => <div>{children}</div>,
-  Button: ({ children }: any) => <button>{children}</button>,
-  Text: ({ children }: any) => <span>{children}</span>,
-  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
-  StateLabel: ({ children }: any) => <span>{children}</span>,
-  Tooltip: ({ children }: any) => <span>{children}</span>,
-}));
-
 const sample: PRItem[] = [
   {
     id: '1',

--- a/src/heroui-shim.tsx
+++ b/src/heroui-shim.tsx
@@ -1,0 +1,120 @@
+/* eslint-disable react/prop-types, react/display-name */
+import React from 'react';
+
+export const Box: React.FC<any> = ({
+  as: Component = 'div',
+  children,
+  ...props
+}) => {
+  const Comp: any = Component;
+  return <Comp {...props}>{children}</Comp>;
+};
+
+export const Text: React.FC<any> = ({
+  as: Component = 'span',
+  children,
+  ...props
+}) => {
+  const Comp: any = Component;
+  return <Comp {...props}>{children}</Comp>;
+};
+
+export const Avatar: React.FC<React.ImgHTMLAttributes<HTMLImageElement>> = (
+  props
+) => <img {...props} />;
+
+export const Button: React.FC<
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+> = ({ children, ...props }) => <button {...props}>{children}</button>;
+
+export const Breadcrumbs: React.FC<{ children?: React.ReactNode }> & {
+  Item: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement>>;
+} = ({ children }) => <nav>{children}</nav>;
+Breadcrumbs.Item = ({ to, href, children, ...props }: any) => (
+  <a href={to || href} {...props}>
+    {children}
+  </a>
+);
+
+export const Input: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = (
+  props
+) => <input {...props} />;
+
+export const Heading: React.FC<any> = ({
+  as: Component = 'h2',
+  children,
+  ...props
+}) => {
+  const Comp: any = Component;
+  return <Comp {...props}>{children}</Comp>;
+};
+
+export const Badge: React.FC<any> = ({ children, ...props }) => (
+  <span {...props}>{children}</span>
+);
+
+export const Spinner: React.FC = () => <span>Loading...</span>;
+
+export const FormControl: React.FC<{ children?: React.ReactNode }> & {
+  Label: React.FC<any>;
+  Caption: React.FC<any>;
+} = ({ children }) => <div>{children}</div>;
+FormControl.Label = ({
+  children,
+  htmlFor,
+  ...props
+}: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+  <label htmlFor={htmlFor} {...props}>
+    {children}
+  </label>
+);
+FormControl.Caption = ({ children }: { children?: React.ReactNode }) => (
+  <span>{children}</span>
+);
+
+export const Select: React.FC<React.SelectHTMLAttributes<HTMLSelectElement>> & {
+  Option: React.FC<React.OptionHTMLAttributes<HTMLOptionElement>>;
+} = ({ children, ...props }) => <select {...props}>{children}</select>;
+Select.Option = (props) => <option {...props}>{props.children}</option>;
+
+export const Timeline: React.FC<{ children?: React.ReactNode }> & {
+  Item: React.FC<{ children?: React.ReactNode }>;
+  Badge: React.FC;
+  Body: React.FC<{ children?: React.ReactNode }>;
+} = ({ children }) => <ul>{children}</ul>;
+Timeline.Item = ({ children }) => <li>{children}</li>;
+Timeline.Badge = () => <span />;
+Timeline.Body = ({ children }) => <div>{children}</div>;
+
+export const TabNav: React.FC<{ children?: React.ReactNode }> & {
+  Link: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement>>;
+} = ({ children }) => <div>{children}</div>;
+TabNav.Link = (props) => <a {...props}>{props.children}</a>;
+
+export const Table = {
+  Pagination: (props: any) => <div {...props} />,
+};
+
+export const DataTable: React.FC<{
+  columns?: any;
+  data?: any;
+  cellPadding?: any;
+}> = ({ children }) => <table>{children}</table>;
+
+export const createColumnHelper = () => ({
+  column: (config: any) => config,
+});
+
+export const StateLabel: React.FC<{
+  status?: string;
+  children?: React.ReactNode;
+}> = ({ children }) => <span>{children}</span>;
+
+export const Tooltip: React.FC<{ children?: React.ReactNode }> = ({
+  children,
+}) => <span>{children}</span>;
+
+export const Link: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement>> = ({
+  children,
+  ...props
+}) => <a {...props}>{children}</a>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "moduleResolution": "Bundler",
     "baseUrl": ".",
     "paths": {
+      "@heroui/react": ["./src/heroui-shim.tsx"],
       "@primer/react": ["./src/primer-shim.tsx"],
       "@primer/react/drafts": ["./src/primer-drafts-shim.tsx"],
       "@primer/octicons-react": ["./src/octicons-shim.tsx"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
   resolve: {
     alias: [
       {
+        find: '@heroui/react',
+        replacement: path.resolve(__dirname, 'src/heroui-shim.tsx'),
+      },
+      {
         find: '@primer/react/drafts',
         replacement: path.resolve(__dirname, 'src/primer-drafts-shim.tsx'),
       },


### PR DESCRIPTION
## Summary
- replace Primer components with heroUI equivalents
- add heroUI shim and update config paths
- adjust MetricsTable tests

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined in MetricsTable.test.tsx)*
- `npx jest src/__tests__/MetricsTable.test.tsx -w=1` *(fails: element type invalid)*


------
https://chatgpt.com/codex/tasks/task_e_6857c0a0bdb8832c8eecb76814601579