### PR TITLE
Switch from octicons to heroicons

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,6 @@ module.exports = {
     '\\.(css|less|scss)$': 'identity-obj-proxy',
     '^@primer/react$': '<rootDir>/src/primer-shim.tsx',
     '^@primer/react/drafts$': '<rootDir>/src/primer-drafts-shim.tsx',
-    '^@primer/octicons-react$': '<rootDir>/src/octicons-shim.tsx',
     '^@heroui/react$': '<rootDir>/src/heroui-shim.tsx'
   },
   coverageThreshold: {

--- a/src/ColorModeToggle.tsx
+++ b/src/ColorModeToggle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MoonIcon, SunIcon } from '@primer/octicons-react';
+import { MoonIcon, SunIcon } from '@heroicons/react/24/solid';
 import { useThemeMode } from './ThemeModeContext';
 
 export default function ColorModeToggle() {

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Avatar, Text, Button, Breadcrumbs } from '@heroui/react';
 import { Octokit } from '@octokit/rest';
-import { TriangleUpIcon, SignOutIcon } from '@primer/octicons-react';
+import {
+  ChevronUpIcon,
+  ArrowRightOnRectangleIcon,
+} from '@heroicons/react/24/solid';
 import { Link as RouterLink } from 'react-router-dom';
 import { useAuth } from './AuthContext';
 import ColorModeToggle from './ColorModeToggle';
@@ -55,7 +58,7 @@ export default function Header({ breadcrumb }: HeaderProps) {
         alignItems="center"
         sx={{ gap: 2, color: 'fg.default' }}
       >
-        <TriangleUpIcon size={24} />
+        <ChevronUpIcon className="icon" width={24} height={24} />
         <Breadcrumbs className="breadcrumbs-modern" sx={{ fontWeight: 'bold' }}>
           <Breadcrumbs.Item as={RouterLink} to="/">
             PR-ism
@@ -74,7 +77,7 @@ export default function Header({ breadcrumb }: HeaderProps) {
           <Text fontSize={1} sx={{ fontFamily: 'mono' }}>
             {user.login}
           </Text>
-          <Button onClick={logout} trailingIcon={SignOutIcon}>
+          <Button onClick={logout} trailingIcon={ArrowRightOnRectangleIcon}>
             Sign out
           </Button>
         </Box>

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -3,10 +3,10 @@ import { Box, Text } from '@heroui/react';
 import { useDocumentTitle } from './hooks/useDocumentTitle';
 import { useMetaDescription } from './hooks/useMetaDescription';
 import {
-  RepoIcon,
-  PeopleIcon,
-  GitPullRequestIcon,
-} from '@primer/octicons-react';
+  FolderIcon,
+  UserGroupIcon,
+  ArrowsRightLeftIcon,
+} from '@heroicons/react/24/solid';
 import { Link as RouterLink } from 'react-router-dom';
 
 export default function Home() {
@@ -32,7 +32,7 @@ export default function Home() {
         }}
       >
         <Box display="flex" alignItems="center" sx={{ gap: 2 }}>
-          <GitPullRequestIcon />
+          <ArrowsRightLeftIcon width={20} height={20} />
           <Text fontSize={2} fontWeight="bold">
             Pull request insights
           </Text>
@@ -60,7 +60,7 @@ export default function Home() {
         }}
       >
         <Box display="flex" alignItems="center" sx={{ gap: 2 }}>
-          <PeopleIcon />
+          <UserGroupIcon width={20} height={20} />
           <Text fontSize={2} fontWeight="bold">
             Developer insights
           </Text>
@@ -88,7 +88,7 @@ export default function Home() {
         }}
       >
         <Box display="flex" alignItems="center" sx={{ gap: 2 }}>
-          <RepoIcon />
+          <FolderIcon width={20} height={20} />
           <Text fontSize={2} fontWeight="bold">
             Repository insights
           </Text>

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Box, Input, Heading, Text, FormControl, Link } from '@heroui/react';
-import { TriangleUpIcon } from '@primer/octicons-react';
+import { ChevronUpIcon } from '@heroicons/react/24/solid';
 import GlowingCard from './GlowingCard';
 import MagicButton from './MagicButton';
 import ColorModeToggle from './ColorModeToggle';
@@ -53,7 +53,7 @@ export default function Login() {
             justifyContent="center"
             sx={{ gap: 2, textAlign: 'center', mb: 3, color: 'fg.default' }}
           >
-            <TriangleUpIcon size={24} />
+            <ChevronUpIcon width={24} height={24} />
             PR-ism
           </Heading>
           <FormControl>

--- a/src/octicons-shim.tsx
+++ b/src/octicons-shim.tsx
@@ -1,9 +1,0 @@
-/* eslint-disable react/prop-types, react/display-name */
-import React from 'react';
-export const RepoIcon = () => <span />;
-export const PeopleIcon = () => <span />;
-export const GitPullRequestIcon = () => <span />;
-export const TriangleUpIcon = (props: any) => <span {...props} />;
-export const SignOutIcon = () => <span />;
-export const MoonIcon = (props: any) => <span {...props} />;
-export const SunIcon = (props: any) => <span {...props} />;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,7 @@
     "paths": {
       "@heroui/react": ["./src/heroui-shim.tsx"],
       "@primer/react": ["./src/primer-shim.tsx"],
-      "@primer/react/drafts": ["./src/primer-drafts-shim.tsx"],
-      "@primer/octicons-react": ["./src/octicons-shim.tsx"]
+      "@primer/react/drafts": ["./src/primer-drafts-shim.tsx"]
     },
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,10 +18,6 @@ export default defineConfig({
         find: '@primer/react',
         replacement: path.resolve(__dirname, 'src/primer-shim.tsx'),
       },
-      {
-        find: '@primer/octicons-react',
-        replacement: path.resolve(__dirname, 'src/octicons-shim.tsx'),
-      },
     ],
   },
   build: {


### PR DESCRIPTION
## Summary
- use heroicon equivalents instead of Octicons
- remove Octicons shims and config mappings

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857cf182a68832c947301bf72d0e0a4