### PR TITLE
Remove unused jsdom polyfills

### DIFF
--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,16 +1,3 @@
 import '@testing-library/jest-dom';
 
-// Primer components rely on CSS.supports which is not implemented in jsdom
-if (typeof (window as any).CSS === 'undefined') {
-  (window as any).CSS = { supports: () => false };
-} else if (typeof (window as any).CSS.supports !== 'function') {
-  (window as any).CSS.supports = () => false;
-}
-
-if (typeof (window as any).ResizeObserver === 'undefined') {
-  (window as any).ResizeObserver = class {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  };
-}
+// HeroUI components do not require CSS or ResizeObserver polyfills in jsdom.


### PR DESCRIPTION
## Summary
- drop CSS.supports workaround and ResizeObserver mock from Jest setup

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857d31b7ce4832c917686c824ca4e4e