### PR TITLE
Replace Primer references with heroUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 PR-ism is a small React and TypeScript application for exploring metrics about your pull requests. It shows how long a pull request stayed in draft, the time to the first review, and the total time until it was merged or closed. The app also lists the reviewers and how many change requests they made.
 
-The user interface uses [HeroUI](https://heroui.com) components to match the look and feel of GitHub. After you sign in with your GitHub token, a table shows the pull requests with filters for repository and author. Selecting a title in the table opens the pull request on GitHub.
+The user interface uses [heroUI](https://heroui.com) components to match GitHub's visual style. After you sign in with your GitHub token, the table lists pull requests with filters for repository and author. Selecting a pull request title opens it on GitHub.
 
 ## Table of Contents
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,6 @@ module.exports = {
   ],
   moduleNameMapper: {
     '\\.(css|less|scss)$': 'identity-obj-proxy',
-    '^@primer/react$': '<rootDir>/src/primer-shim.tsx',
     '^@heroui/react$': '<rootDir>/src/heroui-shim.tsx'
   },
   coverageThreshold: {

--- a/src/GlowingCard.tsx
+++ b/src/GlowingCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box } from '@primer/react';
+import { Box } from '@heroui/react';
 
 interface Props {
   children: React.ReactNode;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,7 @@
     "moduleResolution": "Bundler",
     "baseUrl": ".",
     "paths": {
-      "@heroui/react": ["./src/heroui-shim.tsx"],
-      "@primer/react": ["./src/primer-shim.tsx"]
+      "@heroui/react": ["./src/heroui-shim.tsx"]
     },
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
         find: '@heroui/react',
         replacement: path.resolve(__dirname, 'src/heroui-shim.tsx'),
       },
-      {
-        find: '@primer/react',
-        replacement: path.resolve(__dirname, 'src/primer-shim.tsx'),
-      },
     ],
   },
   build: {


### PR DESCRIPTION
## Summary
- update README to reference heroUI
- drop Primer aliases in configs
- use heroUI for `GlowingCard`

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857d4b61de0832c97d139a9945f3fd3