### PR TITLE
Update tests for HeroUI components

### DIFF
--- a/src/__tests__/ColorModeToggle.test.tsx
+++ b/src/__tests__/ColorModeToggle.test.tsx
@@ -15,7 +15,7 @@ test('toggles theme with accessible switch', async () => {
       <ColorModeToggle />
     </ThemeModeProvider>
   );
-  const toggle = screen.getByRole('switch');
+  const toggle = screen.getByRole('switch', { name: /switch to dark mode/i });
   expect(toggle).toHaveAttribute('aria-checked', 'false');
   await user.click(toggle);
   expect(toggle).toHaveAttribute('aria-checked', 'true');

--- a/src/__tests__/DeveloperMetricsPage.test.tsx
+++ b/src/__tests__/DeveloperMetricsPage.test.tsx
@@ -56,7 +56,7 @@ test('displays suggestions and handles selection', async () => {
     </ThemeModeProvider>
   );
   const user = userEvent.setup();
-  await user.type(screen.getByPlaceholderText(/search github user/i), 'oct');
+  await user.type(screen.getByPlaceholderText(/search github users/i), 'oct');
   await waitFor(() => expect(github.searchUsers).toHaveBeenCalled());
   await waitFor(() => screen.getByText('octo'));
   await user.click(screen.getByText('octo'));
@@ -78,7 +78,7 @@ test('logs error on search failure', async () => {
     </ThemeModeProvider>
   );
   const user = userEvent.setup();
-  await user.type(screen.getByPlaceholderText(/search github user/i), 'oct');
+  await user.type(screen.getByPlaceholderText(/search github users/i), 'oct');
   await waitFor(() => expect(github.searchUsers).toHaveBeenCalled());
   await waitFor(() => expect(spy).toHaveBeenCalled());
   spy.mockRestore();

--- a/src/__tests__/Login.test.tsx
+++ b/src/__tests__/Login.test.tsx
@@ -29,7 +29,7 @@ test('login submits provided token', async () => {
       </AuthProvider>
     </ThemeModeProvider>
   );
-  const input = screen.getByPlaceholderText(/github token/i);
+  const input = screen.getByLabelText(/personal access token/i);
   const user = userEvent.setup();
   await user.type(input, 'token123');
   await user.click(screen.getByRole('button', { name: /sign in/i }));
@@ -49,7 +49,7 @@ test('shows error when token is invalid', async () => {
     </ThemeModeProvider>
   );
   const user = userEvent.setup();
-  await user.type(screen.getByPlaceholderText(/github token/i), 'bad');
+  await user.type(screen.getByLabelText(/personal access token/i), 'bad');
   await user.click(screen.getByRole('button', { name: /sign in/i }));
 
   await waitFor(() =>

--- a/src/__tests__/MetricsTable.test.tsx
+++ b/src/__tests__/MetricsTable.test.tsx
@@ -3,6 +3,8 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import MetricsTable from '../MetricsTable';
 import { AuthProvider } from '../AuthContext';
+
+jest.mock('@heroui/react', () => jest.requireActual('../heroui-shim.tsx'));
 import * as metricsHook from '../hooks/usePullRequestMetrics';
 import { PRItem } from '../types';
 
@@ -45,6 +47,7 @@ test('renders filters and data', () => {
   );
   expect(screen.getByLabelText('Repository')).toBeInTheDocument();
   expect(screen.getByLabelText('Author')).toBeInTheDocument();
+  expect(screen.getByLabelText('Pagination')).toBeInTheDocument();
 });
 
 test('shows spinner when loading', () => {


### PR DESCRIPTION
## Summary
- tweak ColorModeToggle test to use labeled switch
- update Login tests to query by label instead of placeholder
- adjust DeveloperMetricsPage queries for new placeholder
- mock HeroUI components in MetricsTable tests and assert pagination

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857d49f2304832c80af9c73eaaf5725