### PR TITLE
Fix duplicate HeroUIProvider

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { HeroUIProvider } from '@heroui/system';
 import { ThemeModeProvider } from './ThemeModeContext';
 import { BrowserRouter } from 'react-router-dom';
 import './index.css';
@@ -11,11 +10,9 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
       <ThemeModeProvider>
-        <HeroUIProvider>
-          <AuthProvider>
-            <App />
-          </AuthProvider>
-        </HeroUIProvider>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
       </ThemeModeProvider>
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- ensure only one HeroUIProvider is used by wrapping it inside ThemeModeProvider

## Testing
- `npm test --silent`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857d797c3f4832c99cf2ce3feaf552d