### PR TITLE
Remove duplicate test setup file

### DIFF
--- a/src/utils/tests/setupTests.ts
+++ b/src/utils/tests/setupTests.ts
@@ -1,9 +1,0 @@
-import '@testing-library/jest-dom';
-
-// Mock fetch for Octokit in tests
-if (!global.fetch) {
-  global.fetch = jest.fn();
-}
-
-// To silence React Router v7 deprecation warnings in tests, set future flags in your router config where possible.
-// Example: <Router future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>


### PR DESCRIPTION
## Summary
- delete `src/utils/tests/setupTests.ts`
- Jest now only references `src/setupTests.ts`

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bc4d32018832c9c80586361d7f3f1