### PR TITLE
🔒 remove hardcoded storage of auth token in localStorage

### DIFF
--- a/src/contexts/AuthContext/AuthContext.test.tsx
+++ b/src/contexts/AuthContext/AuthContext.test.tsx
@@ -17,7 +17,9 @@ test('login and logout updates token', () => {
 
   act(() => result.current.login('abc'));
   expect(result.current.token).toBe('abc');
+  expect(localStorage.getItem('token')).toBeNull();
 
   act(() => result.current.logout());
   expect(result.current.token).toBeNull();
+  expect(localStorage.getItem('token')).toBeNull();
 });

--- a/src/contexts/AuthContext/AuthContext.tsx
+++ b/src/contexts/AuthContext/AuthContext.tsx
@@ -42,12 +42,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
                   data.session as any
                 );
                 if (provFromExchange) {
-                  localStorage.setItem('token', provFromExchange);
                   setToken(provFromExchange);
                 }
               }
             } catch {
-              // ignore; fall through to getSession/localStorage
+              // ignore; fall through to getSession
             } finally {
               // Clean the URL so code/state are not left behind
               try {
@@ -69,15 +68,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         const session = data?.session as any;
         const prov = extractProviderToken(session);
         if (prov) {
-          localStorage.setItem('token', prov);
           setToken(prov);
           return;
         }
       } catch {
-        // no-op; fallback to localStorage
+        // no-op
       }
-      const stored = localStorage.getItem('token');
-      if (stored) setToken(stored);
     };
     init();
 
@@ -86,10 +82,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       (event: any, sess: any) => {
         const prov = extractProviderToken(sess?.session ?? sess);
         if (prov) {
-          localStorage.setItem('token', prov);
           setToken(prov);
         } else if (event === 'SIGNED_OUT') {
-          localStorage.removeItem('token');
           setToken(null);
         }
       }
@@ -121,7 +115,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [token]);
 
   const login = (newToken: string) => {
-    localStorage.setItem('token', newToken);
     setToken(newToken);
     // Proactively fetch user so tests that assert immediate calls succeed.
     // Use Promise.resolve to avoid calling .then on undefined when the module is auto-mocked in tests.
@@ -134,7 +127,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const logout = () => {
     supabase.auth.signOut?.();
-    localStorage.removeItem('token');
     setToken(null);
     setUser(null);
     navigate('/login');

--- a/src/contexts/AuthContext/__tests__/AuthContext.test.tsx
+++ b/src/contexts/AuthContext/__tests__/AuthContext.test.tsx
@@ -55,7 +55,7 @@ describe('AuthContext', () => {
 
     // token rendered
     expect(await screen.findByTestId('token')).toHaveTextContent('provTok');
-    expect(localStorage.getItem('token')).toBe('provTok');
+    expect(localStorage.getItem('token')).toBeNull();
 
     // Capture subscription to assert cleanup
     const sub = (supabase.auth.onAuthStateChange as jest.Mock).mock.results[0]
@@ -120,7 +120,7 @@ describe('AuthContext', () => {
     await act(async () => {
       screen.getByText('login').click();
     });
-    expect(localStorage.getItem('token')).toBe('tok123');
+    expect(localStorage.getItem('token')).toBeNull();
     expect(await screen.findByTestId('user')).toHaveTextContent('me');
 
     // logout invokes supabase signOut and clears state
@@ -159,7 +159,7 @@ describe('AuthContext', () => {
     window.history.pushState({}, '', '/');
   });
 
-  test('falls back to localStorage token when no Supabase session', async () => {
+  test('does NOT fall back to localStorage token when no Supabase session', async () => {
     // @ts-expect-error test helper
     supabase.auth.__reset?.();
     localStorage.setItem('token', 'fromLS');
@@ -171,16 +171,16 @@ describe('AuthContext', () => {
         </AuthProvider>
       </MemoryRouter>
     );
-    // The AuthProvider init will read localStorage when getSession yields null
+    // The AuthProvider init should NOT read localStorage
     await act(async () => {});
-    await expect(screen.findByTestId('token')).resolves.toHaveTextContent(
-      'fromLS'
-    );
+    expect(screen.getByTestId('token')).toHaveTextContent('');
   });
 
-  test('onAuthStateChange SIGNED_OUT clears token and localStorage', async () => {
-    // Start with an existing token
-    localStorage.setItem('token', 'x');
+  test('onAuthStateChange SIGNED_OUT clears token in memory', async () => {
+    // Start with a login
+    (githubService.getAuthenticatedUserProfile as jest.Mock).mockResolvedValue({
+      login: 'me',
+    });
     render(
       <MemoryRouter>
         <AuthProvider>
@@ -188,9 +188,13 @@ describe('AuthContext', () => {
         </AuthProvider>
       </MemoryRouter>
     );
+    await act(async () => {
+      screen.getByText('login').click();
+    });
+    expect(await screen.findByTestId('token')).toHaveTextContent('tok123');
+
     // @ts-expect-error test helper
     supabase.auth.__emitAuthEvent?.('SIGNED_OUT', null);
-    expect(localStorage.getItem('token')).toBeNull();
     expect(screen.getByTestId('token')).toHaveTextContent('');
   });
 

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -32,7 +32,7 @@ export const supabase = createClient(supabaseUrl || '', supabaseKey || '', {
   auth: {
     autoRefreshToken: true,
     persistSession: true,
-    storage: typeof window !== 'undefined' ? window.localStorage : undefined,
+    storage: typeof window !== 'undefined' ? window.sessionStorage : undefined,
   },
 });
 

--- a/src/pages/RepoInsights/RepoInsightsPage.test.tsx
+++ b/src/pages/RepoInsights/RepoInsightsPage.test.tsx
@@ -10,7 +10,6 @@ jest.mock('../../utils/services/githubService');
 describe('RepoInsightsPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    localStorage.setItem('token', 'tok');
   });
 
   it('does not show dropdown for invalid input', async () => {


### PR DESCRIPTION
The application was insecurely storing GitHub OAuth provider tokens and Personal Access Tokens (PATs) in `localStorage`, which persisted them on disk and exposed them to XSS attacks.

This fix:
1.  **Eliminates `localStorage` usage** for the `'token'` key.
2.  **Transitions to in-memory state** for the active token within the `AuthContext`.
3.  **Hardens session persistence** by configuring the Supabase client to use `sessionStorage` instead of `localStorage`. This ensures that sessions (which contain the provider token) are cleared when the browser tab is closed, while still allowing the application to survive page refreshes during an active session.
4.  **Updates the test suite** to assert that tokens are never written to or read from `localStorage`.

Manual PATs are now memory-only and will be lost on page refresh, which is the intended security posture for sensitive tokens in this frontend-only environment.

---
*PR created automatically by Jules for task [5514036297888620686](https://jules.google.com/task/5514036297888620686) started by @ranjgith-s*