### PR TITLE
🧪 [testing improvement] Add unit tests for MetricsTable utils firstKey function

### DIFF
--- a/src/components/MetricsTable/__tests__/utils.test.ts
+++ b/src/components/MetricsTable/__tests__/utils.test.ts
@@ -1,0 +1,34 @@
+import { firstKey } from '../utils';
+
+describe('firstKey', () => {
+  it('returns empty string for falsy values', () => {
+    expect(firstKey(null)).toBe('');
+    expect(firstKey(undefined)).toBe('');
+    expect(firstKey(false)).toBe('');
+    expect(firstKey(0)).toBe('');
+    expect(firstKey('')).toBe('');
+  });
+
+  it('returns the string itself if passed a string', () => {
+    expect(firstKey('myKey')).toBe('myKey');
+  });
+
+  it('returns the first element if passed an array', () => {
+    expect(firstKey(['key1', 'key2'])).toBe('key1');
+    expect(firstKey([])).toBeUndefined();
+  });
+
+  it('returns the first element if passed a Set', () => {
+    expect(firstKey(new Set(['setKey1', 'setKey2']))).toBe('setKey1');
+    expect(firstKey(new Set())).toBeUndefined();
+  });
+
+  it('returns currentKey if passed an object with currentKey property', () => {
+    expect(firstKey({ currentKey: 'objKey', otherProp: 'value' })).toBe('objKey');
+  });
+
+  it('returns empty string for other objects without currentKey', () => {
+    expect(firstKey({ otherProp: 'value' })).toBe('');
+    expect(firstKey({})).toBe('');
+  });
+});

--- a/src/components/MetricsTable/__tests__/utils.test.ts
+++ b/src/components/MetricsTable/__tests__/utils.test.ts
@@ -24,7 +24,9 @@ describe('firstKey', () => {
   });
 
   it('returns currentKey if passed an object with currentKey property', () => {
-    expect(firstKey({ currentKey: 'objKey', otherProp: 'value' })).toBe('objKey');
+    expect(firstKey({ currentKey: 'objKey', otherProp: 'value' })).toBe(
+      'objKey'
+    );
   });
 
   it('returns empty string for other objects without currentKey', () => {


### PR DESCRIPTION
🎯 What: The testing gap addressed is the missing unit tests for the `firstKey` utility function in `src/components/MetricsTable/utils.ts`.
📊 Coverage: Added tests covering all branches of the `firstKey` function: falsy values (null, undefined, 0, false, ''), strings, arrays, Sets, objects with a `currentKey` property, and fallback cases (unrecognized objects).
✨ Result: Increased test coverage and confidence for the MetricsTable utilities. The code is now protected against regressions with robust unit tests.

---
*PR created automatically by Jules for task [9616058167251368166](https://jules.google.com/task/9616058167251368166) started by @ranjgith-s*