### PR TITLE
🧪 [Testing Improvement] Improve test coverage for validateToken error handling

### DIFF
--- a/src/utils/services/auth.test.ts
+++ b/src/utils/services/auth.test.ts
@@ -33,9 +33,11 @@ describe('validateToken', () => {
     expect(result).toEqual(mockUser);
   });
 
-  it('throws an error for an invalid token or network error', async () => {
+  it('throws an error for a 401 Unauthorized response (invalid token)', async () => {
     const mockError = new Error('Bad credentials');
+    (mockError as any).status = 401;
     const mockGetAuthenticated = jest.fn().mockRejectedValue(mockError);
+
     (Octokit as unknown as jest.Mock).mockImplementation(() => ({
       rest: {
         users: {
@@ -45,6 +47,27 @@ describe('validateToken', () => {
     }));
 
     await expect(validateToken(mockToken)).rejects.toThrow('Bad credentials');
+
+    expect(Octokit).toHaveBeenCalledWith({ auth: mockToken });
+    expect(mockGetAuthenticated).toHaveBeenCalled();
+  });
+
+  it('throws an error for a 500 network error response', async () => {
+    const mockError = new Error('Internal Server Error');
+    (mockError as any).status = 500;
+    const mockGetAuthenticated = jest.fn().mockRejectedValue(mockError);
+
+    (Octokit as unknown as jest.Mock).mockImplementation(() => ({
+      rest: {
+        users: {
+          getAuthenticated: mockGetAuthenticated,
+        },
+      },
+    }));
+
+    await expect(validateToken(mockToken)).rejects.toThrow(
+      'Internal Server Error'
+    );
 
     expect(Octokit).toHaveBeenCalledWith({ auth: mockToken });
     expect(mockGetAuthenticated).toHaveBeenCalled();


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `validateToken` function in `src/utils/services/auth.ts` lacked specific test coverage for different error types such as 401 Unauthorized and 500 Internal Server Error when throwing an error via the Octokit mocked client.

📊 **Coverage:** What scenarios are now tested
1. 401 Unauthorized response (invalid token) specifically checked via rejected promise mock.
2. 500 Network error response specifically checked via rejected promise mock.

✨ **Result:** The improvement in test coverage
The error cases are robustly tested for distinct HTTP failure types which helps prevent regression and verifies error bubbling effectively when invalid tokens or generic server errors occur.

---
*PR created automatically by Jules for task [1014350838782138222](https://jules.google.com/task/1014350838782138222) started by @ranjgith-s*